### PR TITLE
Fix for issue #50

### DIFF
--- a/src/main/java/com/cronutils/model/time/TimeNode.java
+++ b/src/main/java/com/cronutils/model/time/TimeNode.java
@@ -95,6 +95,7 @@ class TimeNode {
         Collections.reverse(values);
         int index=0;
         boolean foundSmaller=false;
+        AtomicInteger shift = new AtomicInteger(0);
         if (!values.contains(reference)) {
             for(Integer value : values){
                 if(value<reference){
@@ -105,12 +106,11 @@ class TimeNode {
                 }
             }
             if(!foundSmaller){
-                shiftsToApply++;
+                shift.incrementAndGet();
             }
         }else{
             index = values.indexOf(reference);
         }
-        AtomicInteger shift = new AtomicInteger(0);
         int value = values.get(index);
         for(int j=0;j<shiftsToApply;j++){
             value = getValueFromList(values, index+1, shift);

--- a/src/test/java/com/cronutils/model/time/TimeNodeTest.java
+++ b/src/test/java/com/cronutils/model/time/TimeNodeTest.java
@@ -21,9 +21,11 @@ import static org.junit.Assert.assertEquals;
  * limitations under the License.
  */
 public class TimeNodeTest {
-    private static final int LIST_START_VALUE = 1;
-    private static final int LIST_MEDIUM_VALUE = 3;
-    private static final int LIST_END_VALUE = 5;
+    private static final int LIST_START_VALUE = 2;
+    private static final int LIST_MEDIUM_VALUE = 4;
+    private static final int LIST_END_VALUE = 6;
+    private static final int LOW_INTERMEDIATE_VALUE = 1;
+    private static final int HIGH_INTERMEDIATE_VALUE = 5;
     private List<Integer> values;
     private TimeNode timeNode;
 
@@ -65,6 +67,9 @@ public class TimeNodeTest {
         assertResult(LIST_MEDIUM_VALUE, 0, timeNode.getPreviousValue(LIST_END_VALUE, 1));
 
         assertResult(LIST_END_VALUE, 1, timeNode.getPreviousValue(LIST_MEDIUM_VALUE, 2));
+
+        assertResult(LIST_MEDIUM_VALUE, 0, timeNode.getPreviousValue(HIGH_INTERMEDIATE_VALUE, 1));
+        assertResult(LIST_END_VALUE, 1, timeNode.getPreviousValue(LOW_INTERMEDIATE_VALUE, 0));
     }
 
     @Test

--- a/src/test/java/com/cronutils/model/time/generator/ExecutionTimeUnixIntegrationTest.java
+++ b/src/test/java/com/cronutils/model/time/generator/ExecutionTimeUnixIntegrationTest.java
@@ -92,4 +92,18 @@ public class ExecutionTimeUnixIntegrationTest {
         ExecutionTime executionTime = ExecutionTime.forCron(cron);
         assertEquals(DateTime.parse("2015-10-19T00:00:00.000-07:00"), executionTime.nextExecution(date));
     }
+
+    /**
+     * Issue #50: last execution does not match expected date when cron specifies day of week and last execution is in previous month.
+     */
+    @Test
+    public void testLastExecutionDaysOfWeekOverMonthBoundary(){
+        String crontab = "0 11 * * 1";
+        CronDefinition cronDefinition = CronDefinitionBuilder.instanceDefinitionFor(CronType.UNIX);
+        CronParser parser = new CronParser(cronDefinition);
+        Cron cron = parser.parse(crontab);
+        DateTime date = DateTime.parse("2015-11-02T00:10:00.000");
+        ExecutionTime executionTime = ExecutionTime.forCron(cron);
+        assertEquals(DateTime.parse("2015-10-26T11:00:00.000"), executionTime.lastExecution(date));
+    }
 }


### PR DESCRIPTION
Fix for TimeNode.getNearestBackwardValue to correctly handle situations where the value we are looking for is not in the current list and there are no smaller values in the list.

This fixes issue #50 where cron definitions containing a day of the week would not be handled correctly when getting the last execution when the last execution was in the previous month.