### PR TITLE
Fix dayofweek and expression

### DIFF
--- a/src/main/java/com/cronutils/model/time/generator/AndDayOfWeekValueGenerator.java
+++ b/src/main/java/com/cronutils/model/time/generator/AndDayOfWeekValueGenerator.java
@@ -1,7 +1,66 @@
 package com.cronutils.model.time.generator;
 
-/**
- * Created by david.wilkie on 23/11/2015.
- */
-public class AndDayOfWeekValueGenerator {
+import com.cronutils.mapper.WeekDay;
+import com.cronutils.model.field.CronField;
+import com.cronutils.model.field.CronFieldName;
+import com.cronutils.model.field.expression.And;
+import com.cronutils.model.field.expression.FieldExpression;
+import com.google.common.collect.Lists;
+import org.apache.commons.lang3.Validate;
+
+import java.util.List;
+
+class AndDayOfWeekValueGenerator extends FieldValueGenerator {
+    private int year;
+    private int month;
+    private WeekDay mondayDoWValue;
+
+    public AndDayOfWeekValueGenerator(CronField cronField, int year, int month, WeekDay mondayDoWValue) {
+        super(cronField.getExpression());
+        Validate.isTrue(CronFieldName.DAY_OF_WEEK.equals(cronField.getField()), "CronField does not belong to day of week");
+        this.year = year;
+        this.month = month;
+        this.mondayDoWValue = mondayDoWValue;
+    }
+
+    protected List<Integer> generateCandidatesNotIncludingIntervalExtremes(int start, int end) {
+        List<Integer> values = Lists.newArrayList();
+        And and = (And) expression;
+
+        for(FieldExpression expression : and.getExpressions()) {
+            CronField cronField = new CronField(CronFieldName.DAY_OF_WEEK, expression);
+            List<Integer> candidatesList = FieldValueGeneratorFactory.createDayOfWeekValueGeneratorInstance(cronField, year, month, mondayDoWValue).generateCandidates(start, end);
+
+            // add them to the master list
+            if (candidatesList != null) {
+                values.addAll(candidatesList);
+            }
+        }
+
+        return values;
+    }
+
+    @Override
+    protected boolean matchesFieldExpressionClass(FieldExpression fieldExpression) {
+        return fieldExpression instanceof And;
+    }
+
+    @Override
+    public int generateNextValue(int reference) throws NoSuchValueException {
+        // This method does not logically work.
+        return 0;
+    }
+
+    @Override
+    public int generatePreviousValue(int reference) throws NoSuchValueException {
+        // This method does not logically work.
+        return 0;
+    }
+
+    @Override
+    public boolean isMatch(int value) {
+        // This method does not logically work.
+        return false;
+    }
+
 }

--- a/src/main/java/com/cronutils/model/time/generator/AndDayOfWeekValueGenerator.java
+++ b/src/main/java/com/cronutils/model/time/generator/AndDayOfWeekValueGenerator.java
@@ -1,0 +1,7 @@
+package com.cronutils.model.time.generator;
+
+/**
+ * Created by david.wilkie on 23/11/2015.
+ */
+public class AndDayOfWeekValueGenerator {
+}

--- a/src/main/java/com/cronutils/model/time/generator/FieldValueGeneratorFactory.java
+++ b/src/main/java/com/cronutils/model/time/generator/FieldValueGeneratorFactory.java
@@ -73,6 +73,10 @@ public class FieldValueGeneratorFactory {
         if (fieldExpression instanceof Between) {
         	return new BetweenDayOfWeekValueGenerator(cronField, year, month, mondayDoWValue);
         }
+        // handle And expression for day of the week as a special case
+        if (fieldExpression instanceof And) {
+            return new AndDayOfWeekValueGenerator(cronField, year, month, mondayDoWValue);
+        }
         return forCronField(cronField);
     }
 

--- a/src/test/java/com/cronutils/model/time/generator/ExecutionTimeUnixIntegrationTest.java
+++ b/src/test/java/com/cronutils/model/time/generator/ExecutionTimeUnixIntegrationTest.java
@@ -106,4 +106,34 @@ public class ExecutionTimeUnixIntegrationTest {
         ExecutionTime executionTime = ExecutionTime.forCron(cron);
         assertEquals(DateTime.parse("2015-10-26T11:00:00.000"), executionTime.lastExecution(date));
     }
+
+    /**
+      * Issue #52: "And" doesn't work for day of the week
+      * 1,2 should be Monday and Tuesday, but instead it is treated as 1st/2nd of month.
+      */
+    @Test
+    public void testWeekdayAndLastExecution() {
+        String crontab = "* * * * 1,2";
+        CronDefinition cronDefinition = CronDefinitionBuilder.instanceDefinitionFor(CronType.UNIX);
+        CronParser parser = new CronParser(cronDefinition);
+        Cron cron = parser.parse(crontab);
+        DateTime date = DateTime.parse("2015-11-10T17:01:00Z");
+        ExecutionTime executionTime = ExecutionTime.forCron(cron);
+        assertEquals(DateTime.parse("2015-11-10T17:00:00Z"), executionTime.lastExecution(date));
+    }
+
+    /**
+     * Isue #52: Additional test to ensure after fix that "And" and "Between" can both be used
+     * 1,2-3 should be Monday, Tuesday and Wednesday.
+     */
+    @Test
+    public void testWeekdayAndWithMixOfOnAndBetweenLastExecution() {
+        String crontab = "* * * * 1,2-3";
+        CronDefinition cronDefinition = CronDefinitionBuilder.instanceDefinitionFor(CronType.UNIX);
+        CronParser parser = new CronParser(cronDefinition);
+        Cron cron = parser.parse(crontab);
+        DateTime date = DateTime.parse("2015-11-10T17:01:00Z");
+        ExecutionTime executionTime = ExecutionTime.forCron(cron);
+        assertEquals(DateTime.parse("2015-11-10T17:00:00Z"), executionTime.lastExecution(date));
+    }
 }

--- a/src/test/java/com/cronutils/model/time/generator/FieldValueGeneratorFactoryTest.java
+++ b/src/test/java/com/cronutils/model/time/generator/FieldValueGeneratorFactoryTest.java
@@ -157,6 +157,26 @@ public class FieldValueGeneratorFactoryTest {
         );
     }
 
+    @Test
+    public void testCreateDayOfWeekValueGeneratorInstance_Between() throws Exception {
+        when(mockCronField.getField()).thenReturn(CronFieldName.DAY_OF_WEEK);
+        when(mockCronField.getExpression()).thenReturn(mock(Between.class));
+        assertEquals(
+                BetweenDayOfWeekValueGenerator.class,
+                FieldValueGeneratorFactory.createDayOfWeekValueGeneratorInstance(mockCronField, 2015, 1, new WeekDay(1, false)).getClass()
+        );
+    }
+
+    @Test
+    public void testCreateDayOfWeekValueGeneratorInstance_And() throws Exception {
+        when(mockCronField.getField()).thenReturn(CronFieldName.DAY_OF_WEEK);
+        when(mockCronField.getExpression()).thenReturn(mock(And.class));
+        assertEquals(
+                AndDayOfWeekValueGenerator.class,
+                FieldValueGeneratorFactory.createDayOfWeekValueGeneratorInstance(mockCronField, 2015, 1, new WeekDay(1, false)).getClass()
+        );
+    }
+
     @Test(expected = IllegalArgumentException.class)
     public void testCreateDayOfWeekValueGeneratorInstanceBadCronFieldName() throws Exception {
         when(mockCronField.getField()).thenReturn(CronFieldName.YEAR);


### PR DESCRIPTION
Fix for issue #52 - Specifying multiple comma separated days of the week in a cron expression was not handled as a special case, so e.g. 1,2 (Monday and Tuesday) was being handled as 1st/2nd of month.