### PR TITLE
Fix incorrect next execution time for "day of month" in "Every" situation

### DIFF
--- a/src/main/java/com/cronutils/model/field/constraint/FieldConstraints.java
+++ b/src/main/java/com/cronutils/model/field/constraint/FieldConstraints.java
@@ -153,6 +153,14 @@ public class FieldConstraints {
         }
     }
 
+    public int getStartRange() {
+        return startRange;
+    }
+
+    public int getEndRange() {
+        return endRange;
+    }
+
     String removeValidChars(String exp){
         Matcher numsAndCharsMatcher = numsAndCharsPattern.matcher(exp);
         Matcher stringToIntKeysMatcher = stringToIntKeysPattern.matcher(numsAndCharsMatcher.replaceAll(""));

--- a/src/main/java/com/cronutils/model/field/expression/FieldExpression.java
+++ b/src/main/java/com/cronutils/model/field/expression/FieldExpression.java
@@ -32,7 +32,7 @@ public abstract class FieldExpression {
         return new And().and(this).and(exp);
     }
 
-    protected FieldConstraints getConstraints() {
+    public FieldConstraints getConstraints() {
         return constraints;
     }
 

--- a/src/main/java/com/cronutils/model/time/generator/EveryFieldValueGenerator.java
+++ b/src/main/java/com/cronutils/model/time/generator/EveryFieldValueGenerator.java
@@ -27,8 +27,7 @@ class EveryFieldValueGenerator extends FieldValueGenerator {
     public int generateNextValue(int reference) throws NoSuchValueException {
         Every every = (Every)expression;
         int period = every.getTime().getValue();
-        int remainder = reference % period;
-        return reference+(period-remainder);
+        return reference + period;
     }
 
     @Override
@@ -61,7 +60,8 @@ class EveryFieldValueGenerator extends FieldValueGenerator {
     @Override
     public boolean isMatch(int value) {
         Every every = (Every)expression;
-        return (value % every.getTime().getValue())==0;
+        int start = every.getConstraints().getStartRange();
+        return ((value-start) % every.getTime().getValue()) == 0;
     }
 
     @Override

--- a/src/test/java/com/cronutils/model/time/generator/ExecutionTimeUnixIntegrationTest.java
+++ b/src/test/java/com/cronutils/model/time/generator/ExecutionTimeUnixIntegrationTest.java
@@ -9,9 +9,7 @@ import com.cronutils.parser.CronParser;
 import org.joda.time.DateTime;
 import org.junit.Test;
 
-
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
 
 public class ExecutionTimeUnixIntegrationTest {
 
@@ -138,18 +136,19 @@ public class ExecutionTimeUnixIntegrationTest {
     }
 
     /**
-     * Issue #59: Incorrect next execution time for "month" and "day of week"
-     * Considers Month in range 0-11 instead of 1-12
+     * Issue #59: Incorrect next execution time for "day of month" in "time" situation
+     * dom "* / 4" should means 1, 5, 9, 13, 17th... of month instead of 4, 8, 12, 16th...
      */
+    @Test
     public void testCorrectMonthScaleForNextExecution(){
         CronDefinition cronDefinition = CronDefinitionBuilder.instanceDefinitionFor(CronType.UNIX);
         CronParser parser = new CronParser(cronDefinition);
-        String crontab = "* * */3 */4 */5";//m,h,dom,M,dow
+        String crontab = "* * */4 * *";//m,h,dom,M,dow
         Cron cron = parser.parse(crontab);
         ExecutionTime executionTime = ExecutionTime.forCron(cron);
         DateTime scanTime = DateTime.parse("2015-12-10T16:32:56.586-08:00");
         DateTime nextExecutionTime = executionTime.nextExecution(scanTime);
-        System.out.println(String.format("Scan time %s, next execution time: %s", scanTime, nextExecutionTime));
+        assertEquals(DateTime.parse("2015-12-13T00:00:00.000-08:00"), nextExecutionTime);
     }
 
     /**
@@ -159,10 +158,10 @@ public class ExecutionTimeUnixIntegrationTest {
     public void testCorrectNextExecutionDoW(){
         CronDefinition cronDefinition = CronDefinitionBuilder.instanceDefinitionFor(CronType.UNIX);
         CronParser parser = new CronParser(cronDefinition);
-        String crontab = "* * */3 */4 */5";
+        String crontab = "* * * * */4";
         Cron cron = parser.parse(crontab);
         ExecutionTime executionTime = ExecutionTime.forCron(cron);
-        DateTime scanTime = DateTime.parse("2015-12-10T16:32:56.586-08:00");
+        DateTime scanTime = DateTime.parse("2016-01-28T16:32:56.586-08:00");
         DateTime nextExecutionTime = executionTime.nextExecution(scanTime);
         System.out.println(String.format("Scan time %s, next execution time: %s", scanTime, nextExecutionTime));
     }


### PR DESCRIPTION
Currently the way to calculate "next value" in "Every" situation is incorrect to me.
For "DoM", the valid range starts from 1 instead of 0, and 1 is always selected for cases like */(a random number). So I purpose a new way to generateNextValue which is "start value + period", and change isMatch to (value - start value) % period.