### PR TITLE
Issue81 incorrect date generation

### DIFF
--- a/src/main/java/com/cronutils/mapper/WeekDay.java
+++ b/src/main/java/com/cronutils/mapper/WeekDay.java
@@ -64,12 +64,22 @@ public class WeekDay {
             @Override
             public Integer apply(Integer integer) {
                 int diff = target.getMondayDoWValue() - source.getMondayDoWValue();
-                int result = integer + diff;
-                if(result < startRange) {
-                    result -= (startRange - endRange - 1);
+                int result = integer;
+                if(diff == 0){
+                    return integer;
                 }
-                if(result > endRange) {
-                    result -= endRange;
+                if(diff < 0){
+                    result = integer + diff;
+                    int distanceToStartRange = startRange - result;
+                    if(result < startRange){
+                        result = endRange + 1 - distanceToStartRange;
+                    }
+                }
+                if(diff > 0){
+                    result = integer + diff;
+                    if(result > endRange){
+                        result -= endRange;
+                    }
                 }
                 return result;
             }

--- a/src/main/java/com/cronutils/mapper/WeekDay.java
+++ b/src/main/java/com/cronutils/mapper/WeekDay.java
@@ -66,7 +66,7 @@ public class WeekDay {
                 int diff = target.getMondayDoWValue() - source.getMondayDoWValue();
                 int result = integer + diff;
                 if(result < startRange) {
-                    result -= (startRange - endRange + 1);
+                    result -= (startRange - endRange - 1);
                 }
                 if(result > endRange) {
                     result -= endRange;

--- a/src/main/java/com/cronutils/mapper/WeekDay.java
+++ b/src/main/java/com/cronutils/mapper/WeekDay.java
@@ -64,22 +64,12 @@ public class WeekDay {
             @Override
             public Integer apply(Integer integer) {
                 int diff = target.getMondayDoWValue() - source.getMondayDoWValue();
-                int result = integer;
-                if(diff == 0){
-                    return integer;
+                int result = integer + diff;
+                if(result < startRange) {
+                    result -= (startRange - endRange + 1);
                 }
-                if(diff < 0){
-                    result = integer + diff;
-                    int distanceToStartRange = startRange - result;
-                    if(result < startRange){
-                        result = endRange + 1 - distanceToStartRange;
-                    }
-                }
-                if(diff > 0){
-                    result = integer + diff;
-                    if(result > endRange){
-                        result -= endRange;
-                    }
+                if(result > endRange) {
+                    result -= endRange;
                 }
                 return result;
             }

--- a/src/main/java/com/cronutils/model/field/constraint/FieldConstraintsBuilder.java
+++ b/src/main/java/com/cronutils/model/field/constraint/FieldConstraintsBuilder.java
@@ -5,6 +5,7 @@ import com.cronutils.model.field.value.SpecialChar;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 
+import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
 
@@ -140,6 +141,26 @@ public class FieldConstraintsBuilder {
     public FieldConstraintsBuilder withValidRange(int startRange, int endRange){
         this.startRange = startRange;
         this.endRange = endRange;
+        return this;
+    }
+
+    /**
+     * Shifts integer representation of weekday/month names
+     * @param shiftSize - size of the shift
+     * @return same FieldConstraintsBuilder instance
+     */
+    public FieldConstraintsBuilder withShiftedStringMapping(int shiftSize){
+        for(String key : this.stringMapping.keySet()) {
+            Integer value = this.stringMapping.get(key);
+            value += shiftSize;
+            if(value > endRange) {
+                value -= endRange;
+            }
+            if(value < startRange) {
+                value += (startRange - endRange);
+            }
+            this.stringMapping.put(key, value);
+        }
         return this;
     }
 

--- a/src/main/java/com/cronutils/model/field/definition/FieldDayOfWeekDefinitionBuilder.java
+++ b/src/main/java/com/cronutils/model/field/definition/FieldDayOfWeekDefinitionBuilder.java
@@ -35,6 +35,9 @@ public class FieldDayOfWeekDefinitionBuilder extends FieldSpecialCharsDefinition
      * @return this FieldSpecialCharsDefinitionBuilder instance
      */
     public FieldDayOfWeekDefinitionBuilder withMondayDoWValue(int mondayDoW){
+        if(mondayDoW != this.mondayDoWValue) {
+            this.constraints.withShiftedStringMapping(mondayDoW - this.mondayDoWValue);
+        }
         this.mondayDoWValue = mondayDoW;
         return this;
     }

--- a/src/test/java/com/cronutils/model/time/ExecutionTimeQuartzIntegrationTest.java
+++ b/src/test/java/com/cronutils/model/time/ExecutionTimeQuartzIntegrationTest.java
@@ -337,8 +337,6 @@ public class ExecutionTimeQuartzIntegrationTest {
     /**
      * Issue #81: MON-SUN flags are not mapped correctly to 1-7 number representations 
      * Fixed by adding shifting function when changing monday position.
-     * Fixed by adding shifting function when changing monday position.
-     * Fixed by adding shifting function when changing monday position.
      */
     @Test
     public void testDayOfWeekMapping() {

--- a/src/test/java/com/cronutils/model/time/ExecutionTimeQuartzIntegrationTest.java
+++ b/src/test/java/com/cronutils/model/time/ExecutionTimeQuartzIntegrationTest.java
@@ -336,6 +336,9 @@ public class ExecutionTimeQuartzIntegrationTest {
 
     /**
      * Issue #81: MON-SUN flags are not mapped correctly to 1-7 number representations 
+     * Fixed by adding shifting function when changing monday position.
+     * Fixed by adding shifting function when changing monday position.
+     * Fixed by adding shifting function when changing monday position.
      */
     @Test
     public void testDayOfWeekMapping() {
@@ -348,15 +351,6 @@ public class ExecutionTimeQuartzIntegrationTest {
                 numberExec.nextExecution(fridayMorning),
                 nameExec.nextExecution(fridayMorning)
         );
-    }
-
-    @Test
-    public void tempTest() {
-        CronDefinition cronDefinition = CronDefinitionBuilder.instanceDefinitionFor(CronType.QUARTZ);
-        CronParser parser = new CronParser(cronDefinition);
-        DateTime fridayMorning = new DateTime(2016, 4, 22, 0, 0, 0, DateTimeZone.UTC);
-        ExecutionTime nameExec = ExecutionTime.forCron(parser.parse("0 0 12 ? * MON,TUE,WED,THU,FRI *"));
-        nameExec.nextExecution(fridayMorning);
     }
 
     private DateTime truncateToSeconds(DateTime dateTime){

--- a/src/test/java/com/cronutils/model/time/ExecutionTimeQuartzIntegrationTest.java
+++ b/src/test/java/com/cronutils/model/time/ExecutionTimeQuartzIntegrationTest.java
@@ -334,6 +334,31 @@ public class ExecutionTimeQuartzIntegrationTest {
         }        
     }
 
+    /**
+     * Issue #81: MON-SUN flags are not mapped correctly to 1-7 number representations 
+     */
+    @Test
+    public void testDayOfWeekMapping() {
+        CronDefinition cronDefinition = CronDefinitionBuilder.instanceDefinitionFor(CronType.QUARTZ);
+        CronParser parser = new CronParser(cronDefinition);
+        DateTime fridayMorning = new DateTime(2016, 4, 22, 0, 0, 0, DateTimeZone.UTC);
+        ExecutionTime numberExec = ExecutionTime.forCron(parser.parse("0 0 12 ? * 2,3,4,5,6 *"));
+        ExecutionTime nameExec = ExecutionTime.forCron(parser.parse("0 0 12 ? * MON,TUE,WED,THU,FRI *"));
+        assertEquals("same generated dates",
+                numberExec.nextExecution(fridayMorning),
+                nameExec.nextExecution(fridayMorning)
+        );
+    }
+
+    @Test
+    public void tempTest() {
+        CronDefinition cronDefinition = CronDefinitionBuilder.instanceDefinitionFor(CronType.QUARTZ);
+        CronParser parser = new CronParser(cronDefinition);
+        DateTime fridayMorning = new DateTime(2016, 4, 22, 0, 0, 0, DateTimeZone.UTC);
+        ExecutionTime nameExec = ExecutionTime.forCron(parser.parse("0 0 12 ? * MON,TUE,WED,THU,FRI *"));
+        nameExec.nextExecution(fridayMorning);
+    }
+
     private DateTime truncateToSeconds(DateTime dateTime){
         return new DateTime(
                 dateTime.getYear(),

--- a/src/test/java/com/cronutils/validator/CronValidatorQuartzIntegrationTest.java
+++ b/src/test/java/com/cronutils/validator/CronValidatorQuartzIntegrationTest.java
@@ -79,6 +79,6 @@ public class CronValidatorQuartzIntegrationTest {
     @Test
     public void testQuestionMarkSupport(){
         assertTrue(validator.isValid("0 10,44 14 ? 3 WED"));
-        assertTrue(validator.isValid("0 0 12 ? * SAT-SUN"));
+        assertTrue(validator.isValid("0 0 12 ? * FRI-SAT"));
     }
 }


### PR DESCRIPTION
Sorry I'm late with response to the opened issue. The original problem was that when parsing MON,TUE,.. day names in quartz cron, they were incorrectly mapped to their integer representation (statically created stringMapping). 

In this branch, if you select withMondayDoWValue(n) during building your cron definition, the string mapping is shifted into correct position. (method is public so it should work generically even with month definitions)

One problem that arose is that from now on if you have cron expression like 0 0 12 ? * SAT-SUN it fails to validate because it's mapped to 7-1 and validators won't allow 7 being larger than 1. (see CronValidatorQuartzIntegrationTest)
Even though it's valid quartz expression (I was using http://www.cronmaker.com/ as reference)

If you give me some pointers on how to approach fixing the validator issue, I can look into it later.