### PR TITLE
Fixing squid:S1118 - Utility classes should not have public constructors

### DIFF
--- a/src/main/java/com/cronutils/descriptor/DescriptionStrategyFactory.java
+++ b/src/main/java/com/cronutils/descriptor/DescriptionStrategyFactory.java
@@ -19,6 +19,9 @@ import java.util.ResourceBundle;
 * limitations under the License.
 */
 class DescriptionStrategyFactory {
+
+    private DescriptionStrategyFactory() {}
+
     /**
      * Creates description strategy for days of week
      * @param bundle - locale

--- a/src/main/java/com/cronutils/mapper/ConstantsMapper.java
+++ b/src/main/java/com/cronutils/mapper/ConstantsMapper.java
@@ -12,6 +12,8 @@ package com.cronutils.mapper;
  * limitations under the License.
  */
 public class ConstantsMapper {
+    private ConstantsMapper() {}
+
     public static final WeekDay QUARTZ_WEEK_DAY = new WeekDay(2, false);
     public static final WeekDay JODATIME_WEEK_DAY = new WeekDay(1, false);
     public static final WeekDay CRONTAB_WEEK_DAY = new WeekDay(1, true);

--- a/src/main/java/com/cronutils/model/field/expression/FieldExpressionFactory.java
+++ b/src/main/java/com/cronutils/model/field/expression/FieldExpressionFactory.java
@@ -19,6 +19,8 @@ import com.cronutils.model.field.value.SpecialCharFieldValue;
 import java.util.List;
 
 public class FieldExpressionFactory {
+    private FieldExpressionFactory() {}
+    
     public static Always always(){
         return new Always();
     }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule
squid:S1118 - "Utility classes should not have public constructors".
You can find more information about the issue here:
https://sonar.spring.io/coding_rules#rule_key=squid:S1118
Please let me know if you have any questions.
Artyom Melnikov