### PR TITLE
#113: removal of guava, htime and commons lang

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,11 +61,10 @@
     <properties>
         <slf4j.version>1.7.12</slf4j.version>
         <log4j.version>1.2.17</log4j.version>
-        <commonsLang.version>3.4</commonsLang.version>
         <junit.version>4.12</junit.version>
         <mockito.version>1.10.19</mockito.version>
         <powermock.version>1.6.2</powermock.version>
-        <htime.version>1.0.0</htime.version>
+        <guava.version>18.0</guava.version>
 
         <github.global.server>github</github.global.server>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -79,23 +78,11 @@
         </dependency>
 
         <dependency>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-lang3</artifactId>
-            <version>${commonsLang.version}</version>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>${guava.version}</version>
+            <scope>test</scope>
         </dependency>
-
-        <dependency>
-            <groupId>com.cronutils</groupId>
-            <artifactId>htime</artifactId>
-            <version>${htime.version}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>joda-time</groupId>
-                    <artifactId>joda-time</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-log4j12</artifactId>

--- a/src/main/java/com/cronutils/StringValidations.java
+++ b/src/main/java/com/cronutils/StringValidations.java
@@ -14,8 +14,8 @@ package com.cronutils;
 
 import com.cronutils.model.field.constraint.FieldConstraints;
 import com.cronutils.model.field.value.SpecialChar;
-import com.google.common.annotations.VisibleForTesting;
-import com.google.common.collect.Sets;
+import com.cronutils.utils.VisibleForTesting;
+import java.util.HashSet;
 
 import java.util.Iterator;
 import java.util.Set;
@@ -53,7 +53,7 @@ public class StringValidations {
 
 	@VisibleForTesting
 	Pattern buildLWPattern(Set<SpecialChar> specialChars) {
-		Set<String> scs = Sets.newHashSet();
+		Set<String> scs = new HashSet<>();
 		for (SpecialChar sc : SPECIAL_CHARS) {
 			if (specialChars.contains(sc)) {
 				scs.add(sc.name());

--- a/src/main/java/com/cronutils/builder/CronBuilder.java
+++ b/src/main/java/com/cronutils/builder/CronBuilder.java
@@ -19,18 +19,18 @@ import com.cronutils.model.field.CronFieldName;
 import com.cronutils.model.field.constraint.FieldConstraints;
 import com.cronutils.model.field.expression.FieldExpression;
 import com.cronutils.model.field.expression.visitor.ValidationFieldExpressionVisitor;
-import com.google.common.annotations.VisibleForTesting;
-import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
+import com.cronutils.utils.VisibleForTesting;
+import java.util.ArrayList;
+import java.util.HashMap;
 
 import java.util.Map;
 
 import static com.cronutils.model.field.CronFieldName.*;
-import static com.google.common.base.Preconditions.checkState;
+import static com.cronutils.utils.Preconditions.checkState;
 
 public class CronBuilder {
 
-	private final Map<CronFieldName, CronField> fields = Maps.newHashMap();
+	private final Map<CronFieldName, CronField> fields = new HashMap<>();
 	private CronDefinition definition;
 
 	private CronBuilder(CronDefinition definition) {
@@ -70,7 +70,7 @@ public class CronBuilder {
 	}
 
 	public Cron instance() {
-		return new Cron(definition, Lists.newArrayList(fields.values())).validate();
+		return new Cron(definition, new ArrayList<>(fields.values())).validate();
 	}
 
 	@VisibleForTesting

--- a/src/main/java/com/cronutils/descriptor/CronDescriptor.java
+++ b/src/main/java/com/cronutils/descriptor/CronDescriptor.java
@@ -3,7 +3,7 @@ package com.cronutils.descriptor;
 import com.cronutils.model.Cron;
 import com.cronutils.model.field.CronField;
 import com.cronutils.model.field.CronFieldName;
-import org.apache.commons.lang3.Validate;
+import com.cronutils.utils.Preconditions;
 
 import java.util.Locale;
 import java.util.Map;
@@ -53,7 +53,7 @@ public class CronDescriptor {
      * @return description - String
      */
     public String describe(Cron cron) {
-        Validate.notNull(cron, "Cron must not be null");
+        Preconditions.checkNotNull(cron, "Cron must not be null");
         Map<CronFieldName, CronField> expressions = cron.retrieveFieldsAsMap();
         return
                 new StringBuilder()

--- a/src/main/java/com/cronutils/descriptor/DescriptionStrategy.java
+++ b/src/main/java/com/cronutils/descriptor/DescriptionStrategy.java
@@ -3,8 +3,8 @@ package com.cronutils.descriptor;
 import com.cronutils.model.field.expression.*;
 import com.cronutils.model.field.value.FieldValue;
 import com.cronutils.model.field.value.IntegerFieldValue;
-import com.google.common.collect.Lists;
-import org.apache.commons.lang3.Validate;
+import com.cronutils.utils.Preconditions;
+import java.util.ArrayList;
 
 import java.text.MessageFormat;
 import java.util.List;
@@ -68,7 +68,7 @@ abstract class DescriptionStrategy {
 	 * @return human readable description - String
 	 */
 	protected String describe(FieldExpression fieldExpression, boolean and) {
-		Validate.notNull(fieldExpression, "CronFieldExpression should not be null!");
+		Preconditions.checkNotNull(fieldExpression, "CronFieldExpression should not be null!");
 		if (fieldExpression instanceof Always) {
 			return describe((Always) fieldExpression, and);
 		}
@@ -96,7 +96,7 @@ abstract class DescriptionStrategy {
 	 * @return String
 	 */
 	protected String nominalValue(FieldValue fieldValue) {
-		Validate.notNull(fieldValue, "FieldValue must not be null");
+		Preconditions.checkNotNull(fieldValue, "FieldValue must not be null");
 		if (fieldValue instanceof IntegerFieldValue) {
 			return nominalValueFunction.apply(((IntegerFieldValue) fieldValue).getValue());
 		}
@@ -122,8 +122,8 @@ abstract class DescriptionStrategy {
 	 * @return human readable description - String
 	 */
 	protected String describe(And and) {
-		List<FieldExpression> expressions = Lists.newArrayList();
-		List<FieldExpression> onExpressions = Lists.newArrayList();
+		List<FieldExpression> expressions = new ArrayList<>();
+		List<FieldExpression> onExpressions = new ArrayList<>();
 		for (FieldExpression fieldExpression : and.getExpressions()) {
 			if (fieldExpression instanceof On) {
 				onExpressions.add(fieldExpression);

--- a/src/main/java/com/cronutils/descriptor/NominalDescriptionStrategy.java
+++ b/src/main/java/com/cronutils/descriptor/NominalDescriptionStrategy.java
@@ -2,7 +2,7 @@ package com.cronutils.descriptor;
 
 import com.cronutils.model.field.expression.Always;
 import com.cronutils.model.field.expression.FieldExpression;
-import com.google.common.collect.Sets;
+import java.util.HashSet;
 
 import java.util.ResourceBundle;
 import java.util.Set;
@@ -39,7 +39,7 @@ class NominalDescriptionStrategy extends DescriptionStrategy {
      */
     public NominalDescriptionStrategy(ResourceBundle bundle, Function<Integer, String> nominalValueFunction, FieldExpression expression) {
         super(bundle);
-        descriptions = Sets.newHashSet();
+        descriptions = new HashSet<>();
         if (nominalValueFunction != null) {
             this.nominalValueFunction = nominalValueFunction;
         }

--- a/src/main/java/com/cronutils/descriptor/TimeDescriptionStrategy.java
+++ b/src/main/java/com/cronutils/descriptor/TimeDescriptionStrategy.java
@@ -2,8 +2,8 @@ package com.cronutils.descriptor;
 
 import com.cronutils.model.field.expression.*;
 import com.cronutils.model.field.value.IntegerFieldValue;
-import com.google.common.collect.Sets;
-import org.apache.commons.lang3.Validate;
+import com.cronutils.utils.Preconditions;
+import java.util.HashSet;
 
 import java.util.ResourceBundle;
 import java.util.Set;
@@ -46,7 +46,7 @@ class TimeDescriptionStrategy extends DescriptionStrategy {
         this.hours = ensureInstance(hours, new Always());
         this.minutes = ensureInstance(minutes, new Always());
         this.seconds = ensureInstance(seconds, new On(new IntegerFieldValue(defaultSeconds)));
-        descriptions = Sets.newHashSet();
+        descriptions = new HashSet<>();
         registerFunctions();
     }
 
@@ -57,7 +57,7 @@ class TimeDescriptionStrategy extends DescriptionStrategy {
      * @return
      */
     private FieldExpression ensureInstance(FieldExpression expression, FieldExpression defaultExpression) {
-        Validate.notNull(defaultExpression, "Default expression must not be null");
+        Preconditions.checkNotNull(defaultExpression, "Default expression must not be null");
         if (expression != null) {
             return expression;
         } else {

--- a/src/main/java/com/cronutils/descriptor/refactor/SecondsDescriptor.java
+++ b/src/main/java/com/cronutils/descriptor/refactor/SecondsDescriptor.java
@@ -4,9 +4,9 @@ import com.cronutils.model.field.expression.*;
 import com.cronutils.model.field.expression.visitor.FieldExpressionVisitor;
 import com.cronutils.model.field.value.FieldValue;
 import com.cronutils.model.field.value.IntegerFieldValue;
-import com.google.common.annotations.VisibleForTesting;
-import com.google.common.collect.Lists;
-import org.apache.commons.lang3.Validate;
+import com.cronutils.utils.Preconditions;
+import com.cronutils.utils.VisibleForTesting;
+import java.util.ArrayList;
 
 import java.text.MessageFormat;
 import java.util.List;
@@ -37,7 +37,7 @@ class SecondsDescriptor implements FieldExpressionVisitor {
      * @return human readable description - String
      */
     protected String describe(FieldExpression fieldExpression, boolean and) {
-        Validate.notNull(fieldExpression, "CronFieldExpression should not be null!");
+        Preconditions.checkNotNull(fieldExpression, "CronFieldExpression should not be null!");
         if (fieldExpression instanceof Always) {
             return describe((Always)fieldExpression, and);
         }
@@ -65,7 +65,7 @@ class SecondsDescriptor implements FieldExpressionVisitor {
      * @return String
      */
     protected String nominalValue(FieldValue fieldValue) {
-        Validate.notNull(fieldValue, "FieldValue must not be null");
+        Preconditions.checkNotNull(fieldValue, "FieldValue must not be null");
         if(fieldValue instanceof IntegerFieldValue){
             return ""+((IntegerFieldValue)fieldValue).getValue();
         }
@@ -87,8 +87,8 @@ class SecondsDescriptor implements FieldExpressionVisitor {
      * @return human readable description - String
      */
     protected String describe(And and) {
-        List<FieldExpression> expressions = Lists.newArrayList();
-        List<FieldExpression> onExpressions = Lists.newArrayList();
+        List<FieldExpression> expressions = new ArrayList<>();
+        List<FieldExpression> onExpressions = new ArrayList<>();
         for(FieldExpression fieldExpression : and.getExpressions()){
             if(fieldExpression instanceof On){
                 onExpressions.add(fieldExpression);

--- a/src/main/java/com/cronutils/mapper/CronMapper.java
+++ b/src/main/java/com/cronutils/mapper/CronMapper.java
@@ -17,10 +17,10 @@ import com.cronutils.model.field.expression.QuestionMark;
 import com.cronutils.model.field.expression.visitor.ValueMappingFieldExpressionVisitor;
 import com.cronutils.model.field.value.IntegerFieldValue;
 import com.cronutils.model.field.value.SpecialChar;
-import com.google.common.annotations.VisibleForTesting;
-import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
-import org.apache.commons.lang3.Validate;
+import com.cronutils.utils.Preconditions;
+import com.cronutils.utils.VisibleForTesting;
+import java.util.ArrayList;
+import java.util.HashMap;
 
 import java.util.List;
 import java.util.Map;
@@ -51,10 +51,10 @@ public class CronMapper {
      *             if null a NullPointerException will be raised
      */
     public CronMapper(CronDefinition from, CronDefinition to, Function<Cron, Cron> cronRules){
-        Validate.notNull(from, "Source CronDefinition must not be null");
-        this.to = Validate.notNull(to, "Destination CronDefinition must not be null");
-        this.cronRules = Validate.notNull(cronRules, "CronRules must not be null");
-        mappings = Maps.newHashMap();
+        Preconditions.checkNotNull(from, "Source CronDefinition must not be null");
+        this.to = Preconditions.checkNotNull(to, "Destination CronDefinition must not be null");
+        this.cronRules = Preconditions.checkNotNull(cronRules, "CronRules must not be null");
+        mappings = new HashMap<>();
         buildMappings(from, to);
     }
 
@@ -65,8 +65,8 @@ public class CronMapper {
      * @return new Cron instance, never null;
      */
     public Cron map(Cron cron) {
-        Validate.notNull(cron, "Cron must not be null");
-        List<CronField> fields = Lists.newArrayList();
+        Preconditions.checkNotNull(cron, "Cron must not be null");
+        List<CronField> fields = new ArrayList<>();
         for(CronFieldName name : CronFieldName.values()){
             if(mappings.containsKey(name)){
                 fields.add(mappings.get(name).apply(cron.retrieve(name)));
@@ -127,7 +127,7 @@ public class CronMapper {
                 if(dow.getExpression() instanceof QuestionMark || dom.getExpression() instanceof QuestionMark){
                     return cron;
                 } else {
-                    Map<CronFieldName, CronField> fields = Maps.newHashMap();
+                    Map<CronFieldName, CronField> fields = new HashMap<>();
                     fields.putAll(cron.retrieveFieldsAsMap());
                     if(dow.getExpression() instanceof Always){
                         fields.put(CronFieldName.DAY_OF_WEEK, new CronField(CronFieldName.DAY_OF_WEEK, new QuestionMark(), fields.get(CronFieldName.DAY_OF_WEEK).getConstraints()));
@@ -138,7 +138,7 @@ public class CronMapper {
                             cron.validate();
                         }
                     }
-                    return new Cron(cron.getCronDefinition(), Lists.<CronField>newArrayList(fields.values()));
+                    return new Cron(cron.getCronDefinition(), new ArrayList<>(fields.values()));
                 }
             }
             return cron;
@@ -155,8 +155,8 @@ public class CronMapper {
      * @param to - target CronDefinition
      */
     private void buildMappings(CronDefinition from, CronDefinition to){
-        Map<CronFieldName, FieldDefinition> sourceFieldDefinitions = Maps.newHashMap();
-        Map<CronFieldName, FieldDefinition> destFieldDefinitions = Maps.newHashMap();
+        Map<CronFieldName, FieldDefinition> sourceFieldDefinitions = new HashMap<>();
+        Map<CronFieldName, FieldDefinition> destFieldDefinitions = new HashMap<>();
         for(FieldDefinition fieldDefinition : from.getFieldDefinitions()){
             sourceFieldDefinitions.put(fieldDefinition.getFieldName(), fieldDefinition);
         }

--- a/src/main/java/com/cronutils/mapper/WeekDay.java
+++ b/src/main/java/com/cronutils/mapper/WeekDay.java
@@ -1,7 +1,7 @@
 package com.cronutils.mapper;
 
-import com.google.common.annotations.VisibleForTesting;
-import org.apache.commons.lang3.Validate;
+import com.cronutils.utils.Preconditions;
+import com.cronutils.utils.VisibleForTesting;
 
 import java.util.function.Function;
 
@@ -23,7 +23,7 @@ public class WeekDay {
     private boolean firstDayZero;
 
     public WeekDay(int mondayDoWValue, boolean firstDayZero){
-        Validate.isTrue(mondayDoWValue>=0, "Monday Day of Week value must be greater or equal to zero");
+        Preconditions.checkArgument(mondayDoWValue>=0, "Monday Day of Week value must be greater or equal to zero");
         this.mondayDoWValue = mondayDoWValue;
         this.firstDayZero = firstDayZero;
     }

--- a/src/main/java/com/cronutils/model/Cron.java
+++ b/src/main/java/com/cronutils/model/Cron.java
@@ -19,8 +19,8 @@ import com.cronutils.model.definition.CronDefinition;
 import com.cronutils.model.field.CronField;
 import com.cronutils.model.field.CronFieldName;
 import com.cronutils.model.field.expression.visitor.ValidationFieldExpressionVisitor;
-import com.google.common.collect.Maps;
-import org.apache.commons.lang3.Validate;
+import com.cronutils.utils.Preconditions;
+import java.util.HashMap;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -36,9 +36,9 @@ public class Cron {
     private String asString;
 
     public Cron(CronDefinition cronDefinition, List<CronField> fields){
-        this.cronDefinition = Validate.notNull(cronDefinition, "CronDefinition must not be null");
-        Validate.notNull(fields, "CronFields cannot be null");
-        this.fields = Maps.newHashMap();
+        this.cronDefinition = Preconditions.checkNotNull(cronDefinition, "CronDefinition must not be null");
+        Preconditions.checkNotNull(fields, "CronFields cannot be null");
+        this.fields = new HashMap<>();
         for(CronField field : fields){
             this.fields.put(field.getField(), field);
         }
@@ -51,7 +51,7 @@ public class Cron {
      * @return CronField that corresponds to given CronFieldName
      */
     public CronField retrieve(CronFieldName name){
-        return fields.get(Validate.notNull(name, "CronFieldName must not be null"));
+        return fields.get(Preconditions.checkNotNull(name, "CronFieldName must not be null"));
     }
 
     /**

--- a/src/main/java/com/cronutils/model/definition/CronDefinition.java
+++ b/src/main/java/com/cronutils/model/definition/CronDefinition.java
@@ -2,8 +2,8 @@ package com.cronutils.model.definition;
 
 import com.cronutils.model.field.CronFieldName;
 import com.cronutils.model.field.definition.FieldDefinition;
-import com.google.common.collect.Maps;
-import org.apache.commons.lang3.Validate;
+import com.cronutils.utils.Preconditions;
+import java.util.HashMap;
 
 import java.util.*;
 
@@ -37,13 +37,13 @@ public class CronDefinition {
      * @param lastFieldOptional - boolean, value stating if last field is optional
      */
     public CronDefinition(List<FieldDefinition> fieldDefinitions, Set<CronConstraint> cronConstraints, boolean lastFieldOptional, boolean strictRanges){
-        Validate.notNull(fieldDefinitions, "Field definitions must not be null");
-        Validate.notNull(cronConstraints, "Cron validations must not be null");
-        Validate.notEmpty(fieldDefinitions, "Field definitions must not be empty");
+        Preconditions.checkNotNull(fieldDefinitions, "Field definitions must not be null");
+        Preconditions.checkNotNull(cronConstraints, "Cron validations must not be null");
+        Preconditions.checkNotNullNorEmpty(fieldDefinitions, "Field definitions must not be empty");
         if(lastFieldOptional){
-            Validate.isTrue(fieldDefinitions.size() > 1, "If last field is optional, field definition must hold at least two fields");
+            Preconditions.checkArgument(fieldDefinitions.size() > 1, "If last field is optional, field definition must hold at least two fields");
         }
-        this.fieldDefinitions = Maps.newHashMap();
+        this.fieldDefinitions = new HashMap<>();
         for(FieldDefinition field : fieldDefinitions){
             this.fieldDefinitions.put(field.getFieldName(), field);
         }

--- a/src/main/java/com/cronutils/model/definition/CronDefinitionBuilder.java
+++ b/src/main/java/com/cronutils/model/definition/CronDefinitionBuilder.java
@@ -8,9 +8,9 @@ import com.cronutils.model.field.definition.FieldDefinition;
 import com.cronutils.model.field.definition.FieldDefinitionBuilder;
 import com.cronutils.model.field.definition.FieldSpecialCharsDefinitionBuilder;
 import com.cronutils.model.field.expression.QuestionMark;
-import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
-import com.google.common.collect.Sets;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
 
 import java.util.HashSet;
 import java.util.Map;
@@ -43,8 +43,8 @@ public class CronDefinitionBuilder {
      * lastFieldOptional is defined false.
      */
     private CronDefinitionBuilder() {
-        fields = Maps.newHashMap();
-        cronConstraints = Sets.newHashSet();
+        fields = new HashMap<>();
+        cronConstraints = new HashSet<>();
         lastFieldOptional = false;
         enforceStrictRanges = false;
     }
@@ -155,7 +155,7 @@ public class CronDefinitionBuilder {
     public CronDefinition instance() {
         Set<CronConstraint> validations = new HashSet<CronConstraint>();
         validations.addAll(cronConstraints);
-        return new CronDefinition(Lists.newArrayList(this.fields.values()), validations, lastFieldOptional, enforceStrictRanges);
+        return new CronDefinition(new ArrayList<>(this.fields.values()), validations, lastFieldOptional, enforceStrictRanges);
     }
 
     /**

--- a/src/main/java/com/cronutils/model/field/CronField.java
+++ b/src/main/java/com/cronutils/model/field/CronField.java
@@ -2,7 +2,7 @@ package com.cronutils.model.field;
 
 import com.cronutils.model.field.constraint.FieldConstraints;
 import com.cronutils.model.field.expression.FieldExpression;
-import org.apache.commons.lang3.Validate;
+import com.cronutils.utils.Preconditions;
 
 import java.util.Comparator;
 
@@ -25,8 +25,8 @@ public class CronField {
 
     public CronField(CronFieldName field, FieldExpression expression, FieldConstraints constraints) {
         this.field = field;
-        this.expression = Validate.notNull(expression, "FieldExpression must not be null");
-        this.constraints = Validate.notNull(constraints, "FieldConstraints must not be null");
+        this.expression = Preconditions.checkNotNull(expression, "FieldExpression must not be null");
+        this.constraints = Preconditions.checkNotNull(constraints, "FieldConstraints must not be null");
     }
 
     public CronFieldName getField() {

--- a/src/main/java/com/cronutils/model/field/constraint/FieldConstraints.java
+++ b/src/main/java/com/cronutils/model/field/constraint/FieldConstraints.java
@@ -1,7 +1,7 @@
 package com.cronutils.model.field.constraint;
 
 import com.cronutils.model.field.value.SpecialChar;
-import org.apache.commons.lang3.Validate;
+import com.cronutils.utils.Preconditions;
 
 import java.util.Collections;
 import java.util.Map;
@@ -43,9 +43,9 @@ public class FieldConstraints {
 	 */
 	public FieldConstraints(Map<String, Integer> stringMapping, Map<Integer, Integer> intMapping, Set<SpecialChar> specialChars, int startRange,
 			int endRange) {
-		this.stringMapping = Collections.unmodifiableMap(Validate.notNull(stringMapping, "String mapping must not be null"));
-		this.intMapping = Collections.unmodifiableMap(Validate.notNull(intMapping, "Integer mapping must not be null"));
-		this.specialChars = Collections.unmodifiableSet(Validate.notNull(specialChars, "Special (non-standard) chars set must not be null"));
+		this.stringMapping = Collections.unmodifiableMap(Preconditions.checkNotNull(stringMapping, "String mapping must not be null"));
+		this.intMapping = Collections.unmodifiableMap(Preconditions.checkNotNull(intMapping, "Integer mapping must not be null"));
+		this.specialChars = Collections.unmodifiableSet(Preconditions.checkNotNull(specialChars, "Special (non-standard) chars set must not be null"));
 		this.startRange = startRange;
 		this.endRange = endRange;
 	}

--- a/src/main/java/com/cronutils/model/field/constraint/FieldConstraintsBuilder.java
+++ b/src/main/java/com/cronutils/model/field/constraint/FieldConstraintsBuilder.java
@@ -2,8 +2,8 @@ package com.cronutils.model.field.constraint;
 
 import com.cronutils.model.field.CronFieldName;
 import com.cronutils.model.field.value.SpecialChar;
-import com.google.common.collect.Maps;
-import com.google.common.collect.Sets;
+import java.util.HashMap;
+import java.util.HashSet;
 
 import java.util.Map;
 import java.util.Set;
@@ -35,11 +35,11 @@ public class FieldConstraintsBuilder {
      * Constructor
      */
     private FieldConstraintsBuilder() {
-        stringMapping = Maps.newHashMap();
-        intMapping = Maps.newHashMap();
+        stringMapping = new HashMap<>();
+        intMapping = new HashMap<>();
         startRange = 0;//no negatives!
         endRange = Integer.MAX_VALUE;
-        specialChars = Sets.newHashSet();
+        specialChars = new HashSet<>();
         specialChars.add(SpecialChar.NONE);
     }
 
@@ -177,7 +177,7 @@ public class FieldConstraintsBuilder {
      * and integers correspond to their 1-7 mappings
      */
     private static Map<String, Integer> daysOfWeekMapping() {
-        Map<String, Integer> stringMapping = Maps.newHashMap();
+        Map<String, Integer> stringMapping = new HashMap<>();
         stringMapping.put("MON", 1);
         stringMapping.put("TUE", 2);
         stringMapping.put("WED", 3);
@@ -194,7 +194,7 @@ public class FieldConstraintsBuilder {
      * and integers correspond to their 1-12 mappings
      */
     private static Map<String, Integer> monthsMapping() {
-        Map<String, Integer> stringMapping = Maps.newHashMap();
+        Map<String, Integer> stringMapping = new HashMap<>();
         stringMapping.put("JAN", 1);
         stringMapping.put("FEB", 2);
         stringMapping.put("MAR", 3);

--- a/src/main/java/com/cronutils/model/field/definition/FieldDayOfWeekDefinitionBuilder.java
+++ b/src/main/java/com/cronutils/model/field/definition/FieldDayOfWeekDefinitionBuilder.java
@@ -3,7 +3,7 @@ package com.cronutils.model.field.definition;
 import com.cronutils.mapper.WeekDay;
 import com.cronutils.model.definition.CronDefinitionBuilder;
 import com.cronutils.model.field.CronFieldName;
-import org.apache.commons.lang3.Validate;
+import com.cronutils.utils.Preconditions;
 
 /*
  * Copyright 2015 jmrozanec
@@ -28,7 +28,7 @@ public class FieldDayOfWeekDefinitionBuilder extends FieldSpecialCharsDefinition
      */
     public FieldDayOfWeekDefinitionBuilder(CronDefinitionBuilder cronDefinitionBuilder, CronFieldName fieldName) {
         super(cronDefinitionBuilder, fieldName);
-        Validate.isTrue(CronFieldName.DAY_OF_WEEK.equals(fieldName), "CronFieldName must be DAY_OF_WEEK");
+        Preconditions.checkArgument(CronFieldName.DAY_OF_WEEK.equals(fieldName), "CronFieldName must be DAY_OF_WEEK");
     }
 
     /**

--- a/src/main/java/com/cronutils/model/field/definition/FieldDefinition.java
+++ b/src/main/java/com/cronutils/model/field/definition/FieldDefinition.java
@@ -15,7 +15,7 @@ package com.cronutils.model.field.definition;
 
 import com.cronutils.model.field.CronFieldName;
 import com.cronutils.model.field.constraint.FieldConstraints;
-import org.apache.commons.lang3.Validate;
+import com.cronutils.utils.Preconditions;
 
 import java.util.Comparator;
 
@@ -34,8 +34,8 @@ public class FieldDefinition {
      *                    if null, a NullPointerException will be raised.
      */
     public FieldDefinition(CronFieldName fieldName, FieldConstraints constraints){
-        this.fieldName = Validate.notNull(fieldName, "CronFieldName must not be null");
-        this.constraints = Validate.notNull(constraints, "FieldConstraints must not be null");
+        this.fieldName = Preconditions.checkNotNull(fieldName, "CronFieldName must not be null");
+        this.constraints = Preconditions.checkNotNull(constraints, "FieldConstraints must not be null");
     }
 
     /**

--- a/src/main/java/com/cronutils/model/field/definition/FieldDefinitionBuilder.java
+++ b/src/main/java/com/cronutils/model/field/definition/FieldDefinitionBuilder.java
@@ -3,7 +3,7 @@ package com.cronutils.model.field.definition;
 import com.cronutils.model.definition.CronDefinitionBuilder;
 import com.cronutils.model.field.CronFieldName;
 import com.cronutils.model.field.constraint.FieldConstraintsBuilder;
-import org.apache.commons.lang3.Validate;
+import com.cronutils.utils.Preconditions;
 
 /*
  * Copyright 2014 jmrozanec
@@ -33,8 +33,8 @@ public class FieldDefinitionBuilder {
      *                  if null, a NullPointerException will be raised
      */
     public FieldDefinitionBuilder(CronDefinitionBuilder cronDefinitionBuilder, CronFieldName fieldName){
-        this.cronDefinitionBuilder = Validate.notNull(cronDefinitionBuilder, "ParserBuilder must not be null");
-        this.fieldName = Validate.notNull(fieldName, "CronFieldName must not be null");
+        this.cronDefinitionBuilder = Preconditions.checkNotNull(cronDefinitionBuilder, "ParserBuilder must not be null");
+        this.fieldName = Preconditions.checkNotNull(fieldName, "CronFieldName must not be null");
         this.constraints = FieldConstraintsBuilder.instance().forField(fieldName);
     }
 

--- a/src/main/java/com/cronutils/model/field/expression/And.java
+++ b/src/main/java/com/cronutils/model/field/expression/And.java
@@ -1,6 +1,6 @@
 package com.cronutils.model.field.expression;
 
-import com.google.common.collect.Lists;
+import java.util.ArrayList;
 
 import java.util.Collections;
 import java.util.List;
@@ -25,11 +25,11 @@ public class And extends FieldExpression {
 	private final List<FieldExpression> expressions;
 
 	public And() {
-		expressions = Lists.newArrayList();
+		expressions = new ArrayList<>();
 	}
 
 	private And(And and) {
-		expressions = Lists.newArrayList(and.getExpressions());
+		expressions = new ArrayList<>(and.getExpressions());
 	}
 
 	@Override

--- a/src/main/java/com/cronutils/model/field/expression/Every.java
+++ b/src/main/java/com/cronutils/model/field/expression/Every.java
@@ -1,7 +1,7 @@
 package com.cronutils.model.field.expression;
 
 import com.cronutils.model.field.value.IntegerFieldValue;
-import org.apache.commons.lang3.Validate;
+import com.cronutils.utils.Preconditions;
 
 /*
  * Copyright 2014 jmrozanec
@@ -32,7 +32,7 @@ public class Every extends FieldExpression {
 	}
 
 	public Every(FieldExpression expression, IntegerFieldValue period) {
-		this.expression = Validate.notNull(expression, "Expression must not be null");
+		this.expression = Preconditions.checkNotNull(expression, "Expression must not be null");
 		this.period = period == null ? new IntegerFieldValue(1) : period;
 	}
 

--- a/src/main/java/com/cronutils/model/field/expression/FieldExpression.java
+++ b/src/main/java/com/cronutils/model/field/expression/FieldExpression.java
@@ -1,7 +1,7 @@
 package com.cronutils.model.field.expression;
 
 import com.cronutils.model.field.expression.visitor.FieldExpressionVisitor;
-import org.apache.commons.lang3.Validate;
+import com.cronutils.utils.Preconditions;
 
 /*
  * Copyright 2015 jmrozanec
@@ -38,7 +38,7 @@ public abstract class FieldExpression {
 	 * @return FieldExpression copied instance with visitor action performed.
 	 */
 	public final FieldExpression accept(FieldExpressionVisitor visitor) {
-		Validate.notNull(visitor, "FieldExpressionVisitor must not be null");
+		Preconditions.checkNotNull(visitor, "FieldExpressionVisitor must not be null");
 		return visitor.visit(this);
 	}
 }

--- a/src/main/java/com/cronutils/model/field/expression/On.java
+++ b/src/main/java/com/cronutils/model/field/expression/On.java
@@ -3,9 +3,9 @@ package com.cronutils.model.field.expression;
 import com.cronutils.model.field.value.IntegerFieldValue;
 import com.cronutils.model.field.value.SpecialChar;
 import com.cronutils.model.field.value.SpecialCharFieldValue;
-import org.apache.commons.lang3.Validate;
+import com.cronutils.utils.Preconditions;
 
-import static com.google.common.base.Preconditions.checkArgument;
+import static com.cronutils.utils.Preconditions.checkArgument;
 
 /*
  * Copyright 2014 jmrozanec
@@ -43,9 +43,9 @@ public class On extends FieldExpression {
 	}
 
 	public On(IntegerFieldValue time, SpecialCharFieldValue specialChar, IntegerFieldValue nth) {
-		Validate.notNull(time, "time must not be null");
-		Validate.notNull(specialChar, "special char must not null");
-		Validate.notNull(nth, "nth value must not be null");
+		Preconditions.checkNotNull(time, "time must not be null");
+		Preconditions.checkNotNull(specialChar, "special char must not null");
+		Preconditions.checkNotNull(nth, "nth value must not be null");
 
 		this.time = time;
 		this.specialChar = specialChar;

--- a/src/main/java/com/cronutils/model/field/expression/visitor/ValidationFieldExpressionVisitor.java
+++ b/src/main/java/com/cronutils/model/field/expression/visitor/ValidationFieldExpressionVisitor.java
@@ -19,7 +19,7 @@ import com.cronutils.model.field.value.FieldValue;
 import com.cronutils.model.field.value.IntegerFieldValue;
 import com.cronutils.model.field.value.SpecialChar;
 import com.cronutils.model.field.value.SpecialCharFieldValue;
-import com.google.common.annotations.VisibleForTesting;
+import com.cronutils.utils.VisibleForTesting;
 
 public class ValidationFieldExpressionVisitor implements FieldExpressionVisitor {
 

--- a/src/main/java/com/cronutils/model/time/ExecutionTime.java
+++ b/src/main/java/com/cronutils/model/time/ExecutionTime.java
@@ -10,10 +10,11 @@ import com.cronutils.model.field.expression.Always;
 import com.cronutils.model.field.expression.QuestionMark;
 import com.cronutils.model.time.generator.FieldValueGenerator;
 import com.cronutils.model.time.generator.NoSuchValueException;
-import com.google.common.annotations.VisibleForTesting;
-import com.google.common.collect.Lists;
-import com.google.common.collect.Sets;
-import org.apache.commons.lang3.Validate;
+import com.cronutils.utils.Preconditions;
+import com.cronutils.utils.VisibleForTesting;
+import java.util.ArrayList;
+import java.util.HashSet;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -62,14 +63,14 @@ public class ExecutionTime {
     ExecutionTime(CronDefinition cronDefinition, FieldValueGenerator yearsValueGenerator, CronField daysOfWeekCronField,
                   CronField daysOfMonthCronField, TimeNode months, TimeNode hours,
                   TimeNode minutes, TimeNode seconds) {
-        this.cronDefinition = Validate.notNull(cronDefinition);
-        this.yearsValueGenerator = Validate.notNull(yearsValueGenerator);
-        this.daysOfWeekCronField = Validate.notNull(daysOfWeekCronField);
-        this.daysOfMonthCronField = Validate.notNull(daysOfMonthCronField);
-        this.months = Validate.notNull(months);
-        this.hours = Validate.notNull(hours);
-        this.minutes = Validate.notNull(minutes);
-        this.seconds = Validate.notNull(seconds);
+        this.cronDefinition = Preconditions.checkNotNull(cronDefinition);
+        this.yearsValueGenerator = Preconditions.checkNotNull(yearsValueGenerator);
+        this.daysOfWeekCronField = Preconditions.checkNotNull(daysOfWeekCronField);
+        this.daysOfMonthCronField = Preconditions.checkNotNull(daysOfMonthCronField);
+        this.months = Preconditions.checkNotNull(months);
+        this.hours = Preconditions.checkNotNull(hours);
+        this.minutes = Preconditions.checkNotNull(minutes);
+        this.seconds = Preconditions.checkNotNull(seconds);
     }
 
     /**
@@ -118,7 +119,7 @@ public class ExecutionTime {
      * @return ZonedDateTime instance, never null. Next execution time.
      */
     public ZonedDateTime nextExecution(ZonedDateTime date) {
-        Validate.notNull(date);
+        Preconditions.checkNotNull(date);
         try {
             ZonedDateTime nextMatch = nextClosestMatch(date);
             if(nextMatch.equals(date)){
@@ -352,7 +353,7 @@ public class ExecutionTime {
      * @return ZonedDateTime instance, never null. Last execution time.
      */
     public ZonedDateTime lastExecution(ZonedDateTime date){
-        Validate.notNull(date);
+        Preconditions.checkNotNull(date);
         try {
             ZonedDateTime previousMatch = previousClosestMatch(date);
             if(previousMatch.equals(date)){
@@ -385,7 +386,7 @@ public class ExecutionTime {
 	private List<Integer> generateDayCandidatesQuestionMarkNotSupported(int year, int month, WeekDay mondayDoWValue) {
         LocalDate date = LocalDate.of(year, month, 1);
         int lengthOfMonth = date.lengthOfMonth();
-        Set<Integer> candidates = Sets.newHashSet();
+        Set<Integer> candidates = new HashSet<>();
         if (daysOfMonthCronField.getExpression() instanceof Always && daysOfWeekCronField.getExpression() instanceof Always) {
             candidates.addAll(createDayOfMonthValueGeneratorInstance(daysOfMonthCronField,
                     year, month).generateCandidates(1, lengthOfMonth));
@@ -401,7 +402,7 @@ public class ExecutionTime {
             candidates.addAll(createDayOfMonthValueGeneratorInstance(daysOfMonthCronField, year, month)
                     .generateCandidates(1, lengthOfMonth));
         }
-        List<Integer> candidatesList = Lists.newArrayList(candidates);
+        List<Integer> candidatesList = new ArrayList<>(candidates);
 		Collections.sort(candidatesList);
 		return candidatesList;
 	}
@@ -409,7 +410,7 @@ public class ExecutionTime {
     private List<Integer> generateDayCandidatesQuestionMarkSupported(int year, int month, WeekDay mondayDoWValue){
         LocalDate date = LocalDate.of(year, month, 1);
         int lengthOfMonth = date.lengthOfMonth();
-        Set<Integer> candidates = Sets.newHashSet();
+        Set<Integer> candidates = new HashSet<>();
         if (daysOfMonthCronField.getExpression() instanceof Always && daysOfWeekCronField.getExpression() instanceof Always) {
             candidates.addAll(createDayOfMonthValueGeneratorInstance(daysOfMonthCronField, year, month)
                     .generateCandidates(1, lengthOfMonth));
@@ -426,7 +427,7 @@ public class ExecutionTime {
             candidates.addAll(createDayOfMonthValueGeneratorInstance(daysOfMonthCronField, year, month)
                     .generateCandidates(1, lengthOfMonth));
         }
-        List<Integer> candidatesList = Lists.newArrayList(candidates);
+        List<Integer> candidatesList = new ArrayList<>(candidates);
         Collections.sort(candidatesList);
         return candidatesList;
     }

--- a/src/main/java/com/cronutils/model/time/ExecutionTimeBuilder.java
+++ b/src/main/java/com/cronutils/model/time/ExecutionTimeBuilder.java
@@ -10,7 +10,7 @@ import com.cronutils.model.field.expression.On;
 import com.cronutils.model.field.value.IntegerFieldValue;
 import com.cronutils.model.time.generator.FieldValueGenerator;
 import com.cronutils.model.time.generator.FieldValueGeneratorFactory;
-import org.apache.commons.lang3.Validate;
+import com.cronutils.utils.Preconditions;
 /*
  * Copyright 2015 jmrozanec
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -148,8 +148,8 @@ class ExecutionTimeBuilder {
     }
 
     private void validate(CronFieldName name, CronField cronField){
-        Validate.notNull(name, "Reference CronFieldName cannot be null");
-        Validate.notNull(cronField.getField(), "CronField's CronFieldName cannot be null");
+        Preconditions.checkNotNull(name, "Reference CronFieldName cannot be null");
+        Preconditions.checkNotNull(cronField.getField(), "CronField's CronFieldName cannot be null");
         if(!name.equals(cronField.getField())){
             throw new IllegalArgumentException(
                     String.format("Invalid argument! Expected CronField instance for field %s but found %s", cronField.getField(), name)

--- a/src/main/java/com/cronutils/model/time/TimeNode.java
+++ b/src/main/java/com/cronutils/model/time/TimeNode.java
@@ -1,12 +1,12 @@
 package com.cronutils.model.time;
 
-import com.google.common.annotations.VisibleForTesting;
-import org.apache.commons.lang3.Validate;
-
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
+
+import com.cronutils.utils.Preconditions;
+import com.cronutils.utils.VisibleForTesting;
 
 /*
  * Copyright 2015 jmrozanec
@@ -24,7 +24,7 @@ class TimeNode {
     protected List<Integer> values;
 
     public TimeNode(List<Integer> values){
-        this.values = Validate.notEmpty(values, "Values must not be empty");
+        this.values = Preconditions.checkNotNullNorEmpty(values, "Values must not be empty");
         Collections.sort(this.values);
     }
 
@@ -124,7 +124,7 @@ class TimeNode {
      */
     @VisibleForTesting
     int getValueFromList(List<Integer>values, int index, AtomicInteger shift){
-        Validate.notEmpty(values, "List must not be empty");
+        Preconditions.checkNotNullNorEmpty(values, "List must not be empty");
         if(index<0){
             index=index+values.size();
             shift.incrementAndGet();

--- a/src/main/java/com/cronutils/model/time/generator/AlwaysFieldValueGenerator.java
+++ b/src/main/java/com/cronutils/model/time/generator/AlwaysFieldValueGenerator.java
@@ -3,7 +3,7 @@ package com.cronutils.model.time.generator;
 import com.cronutils.model.field.CronField;
 import com.cronutils.model.field.expression.Always;
 import com.cronutils.model.field.expression.FieldExpression;
-import com.google.common.collect.Lists;
+import java.util.ArrayList;
 
 import java.util.List;
 /*
@@ -45,7 +45,7 @@ class AlwaysFieldValueGenerator extends FieldValueGenerator {
 
     @Override
     protected List<Integer> generateCandidatesNotIncludingIntervalExtremes(int start, int end) {
-        List<Integer> values = Lists.newArrayList();
+        List<Integer> values = new ArrayList<>();
         for(int j = start+1; j<end; j++){
             values.add(j);
         }

--- a/src/main/java/com/cronutils/model/time/generator/AndDayOfWeekValueGenerator.java
+++ b/src/main/java/com/cronutils/model/time/generator/AndDayOfWeekValueGenerator.java
@@ -5,8 +5,8 @@ import com.cronutils.model.field.CronField;
 import com.cronutils.model.field.CronFieldName;
 import com.cronutils.model.field.expression.And;
 import com.cronutils.model.field.expression.FieldExpression;
-import com.google.common.collect.Lists;
-import org.apache.commons.lang3.Validate;
+import com.cronutils.utils.Preconditions;
+import java.util.ArrayList;
 
 import java.util.List;
 
@@ -17,14 +17,14 @@ class AndDayOfWeekValueGenerator extends FieldValueGenerator {
 
     public AndDayOfWeekValueGenerator(CronField cronField, int year, int month, WeekDay mondayDoWValue) {
         super(cronField);
-        Validate.isTrue(CronFieldName.DAY_OF_WEEK.equals(cronField.getField()), "CronField does not belong to day of week");
+        Preconditions.checkArgument(CronFieldName.DAY_OF_WEEK.equals(cronField.getField()), "CronField does not belong to day of week");
         this.year = year;
         this.month = month;
         this.mondayDoWValue = mondayDoWValue;
     }
 
     protected List<Integer> generateCandidatesNotIncludingIntervalExtremes(int start, int end) {
-        List<Integer> values = Lists.newArrayList();
+        List<Integer> values = new ArrayList<>();
         And and = (And) cronField.getExpression();
 
         for(FieldExpression expression : and.getExpressions()) {

--- a/src/main/java/com/cronutils/model/time/generator/AndFieldValueGenerator.java
+++ b/src/main/java/com/cronutils/model/time/generator/AndFieldValueGenerator.java
@@ -2,7 +2,7 @@ package com.cronutils.model.time.generator;
 
 import com.cronutils.model.field.CronField;
 import com.cronutils.model.field.expression.*;
-import com.google.common.collect.Lists;
+import java.util.ArrayList;
 
 import java.util.List;
 import java.util.function.Function;
@@ -65,7 +65,7 @@ class AndFieldValueGenerator extends FieldValueGenerator {
 
     @Override
     protected List<Integer> generateCandidatesNotIncludingIntervalExtremes(int start, int end) {
-        List<Integer> values = Lists.newArrayList();
+        List<Integer> values = new ArrayList<>();
         try {
             int reference = generateNextValue(start);
             while(reference<end){
@@ -95,7 +95,7 @@ class AndFieldValueGenerator extends FieldValueGenerator {
 
     private List<Integer> computeCandidates(Function<FieldValueGenerator, Integer> function){
         And and = (And) cronField.getExpression();
-        List<Integer> candidates = Lists.newArrayList();
+        List<Integer> candidates = new ArrayList<>();
         for (FieldExpression expression : and.getExpressions()) {
             candidates.add(function.apply(createCandidateGeneratorInstance(new CronField(cronField.getField(), expression, cronField.getConstraints()))));
         }

--- a/src/main/java/com/cronutils/model/time/generator/BetweenDayOfWeekValueGenerator.java
+++ b/src/main/java/com/cronutils/model/time/generator/BetweenDayOfWeekValueGenerator.java
@@ -7,9 +7,9 @@ import com.cronutils.model.field.constraint.FieldConstraintsBuilder;
 import com.cronutils.model.field.expression.Between;
 import com.cronutils.model.field.expression.FieldExpression;
 import com.cronutils.parser.CronParserField;
-import com.google.common.collect.Lists;
-import com.google.common.collect.Sets;
-import org.apache.commons.lang3.Validate;
+import com.cronutils.utils.Preconditions;
+import java.util.ArrayList;
+import java.util.HashSet;
 
 import java.time.LocalDate;
 import java.util.Collections;
@@ -51,11 +51,11 @@ class BetweenDayOfWeekValueGenerator extends FieldValueGenerator {
     
     public BetweenDayOfWeekValueGenerator(CronField cronField, int year, int month, WeekDay mondayDoWValue) {
         super(cronField);
-        Validate.isTrue(CronFieldName.DAY_OF_WEEK.equals(cronField.getField()), "CronField does not belong to day of week");
+        Preconditions.checkArgument(CronFieldName.DAY_OF_WEEK.equals(cronField.getField()), "CronField does not belong to day of week");
         this.year = year;
         this.month = month;
         this.mondayDoWValue = mondayDoWValue;
-        dowValidValues = Sets.newHashSet();
+        dowValidValues = new HashSet<>();
         Between between = (Between) cronField.getExpression();
         int from = (Integer) between.getFrom().getValue();
         int to = (Integer) between.getTo().getValue();
@@ -67,7 +67,7 @@ class BetweenDayOfWeekValueGenerator extends FieldValueGenerator {
 
     @Override
     protected List<Integer> generateCandidatesNotIncludingIntervalExtremes(int start, int end) {
-        List<Integer>values = Lists.newArrayList();
+        List<Integer>values = new ArrayList<>();
         Between between = (Between) cronField.getExpression();
         
         // we have a range of days of week, so we will generate a list for each day and then combine them

--- a/src/main/java/com/cronutils/model/time/generator/BetweenFieldValueGenerator.java
+++ b/src/main/java/com/cronutils/model/time/generator/BetweenFieldValueGenerator.java
@@ -5,7 +5,7 @@ import com.cronutils.model.field.expression.Between;
 import com.cronutils.model.field.expression.FieldExpression;
 import com.cronutils.model.field.value.FieldValue;
 import com.cronutils.model.field.value.IntegerFieldValue;
-import com.google.common.collect.Lists;
+import java.util.ArrayList;
 
 import java.util.List;
 /*
@@ -58,7 +58,7 @@ class BetweenFieldValueGenerator extends FieldValueGenerator {
 
     @Override
     protected List<Integer> generateCandidatesNotIncludingIntervalExtremes(int start, int end) {
-        List<Integer> values = Lists.newArrayList();
+        List<Integer> values = new ArrayList<>();
         //check overlapping ranges: x1 <= y2 && y1 <= x2
         Between between = (Between)cronField.getExpression();
         int expressionStart = map(between.getFrom());

--- a/src/main/java/com/cronutils/model/time/generator/EveryFieldValueGenerator.java
+++ b/src/main/java/com/cronutils/model/time/generator/EveryFieldValueGenerator.java
@@ -3,8 +3,8 @@ package com.cronutils.model.time.generator;
 import com.cronutils.model.field.CronField;
 import com.cronutils.model.field.expression.Every;
 import com.cronutils.model.field.expression.FieldExpression;
-import com.google.common.annotations.VisibleForTesting;
-import com.google.common.collect.Lists;
+import com.cronutils.utils.VisibleForTesting;
+import java.util.ArrayList;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -68,7 +68,7 @@ class EveryFieldValueGenerator extends FieldValueGenerator {
 
     @Override
     protected List<Integer> generateCandidatesNotIncludingIntervalExtremes(int start, int end) {
-        List<Integer>values = Lists.newArrayList();
+        List<Integer>values = new ArrayList<>();
         try {
             int reference = generateNextValue(start);
             while(reference<end){

--- a/src/main/java/com/cronutils/model/time/generator/FieldValueGenerator.java
+++ b/src/main/java/com/cronutils/model/time/generator/FieldValueGenerator.java
@@ -2,7 +2,7 @@ package com.cronutils.model.time.generator;
 
 import com.cronutils.model.field.CronField;
 import com.cronutils.model.field.expression.FieldExpression;
-import org.apache.commons.lang3.Validate;
+import com.cronutils.utils.Preconditions;
 
 import java.util.Collections;
 import java.util.List;
@@ -29,8 +29,8 @@ public abstract class FieldValueGenerator {
 	protected CronField cronField;
 
 	public FieldValueGenerator(CronField cronField) {
-		this.cronField = Validate.notNull(cronField, "CronField must not be null");
-		Validate.isTrue(matchesFieldExpressionClass(cronField.getExpression()), "FieldExpression does not match required class");
+		this.cronField = Preconditions.checkNotNull(cronField, "CronField must not be null");
+		Preconditions.checkArgument(matchesFieldExpressionClass(cronField.getExpression()), "FieldExpression does not match required class");
 	}
 
 	/**

--- a/src/main/java/com/cronutils/model/time/generator/NullFieldValueGenerator.java
+++ b/src/main/java/com/cronutils/model/time/generator/NullFieldValueGenerator.java
@@ -2,7 +2,7 @@ package com.cronutils.model.time.generator;
 
 import com.cronutils.model.field.CronField;
 import com.cronutils.model.field.expression.FieldExpression;
-import com.google.common.collect.Lists;
+import java.util.ArrayList;
 
 import java.util.List;
 /*
@@ -34,7 +34,7 @@ class NullFieldValueGenerator extends FieldValueGenerator {
 
     @Override
     protected List<Integer> generateCandidatesNotIncludingIntervalExtremes(int start, int end) {
-        return Lists.newArrayList();
+        return new ArrayList<>();
     }
 
     @Override

--- a/src/main/java/com/cronutils/model/time/generator/OnDayOfMonthValueGenerator.java
+++ b/src/main/java/com/cronutils/model/time/generator/OnDayOfMonthValueGenerator.java
@@ -4,8 +4,8 @@ import com.cronutils.model.field.CronField;
 import com.cronutils.model.field.CronFieldName;
 import com.cronutils.model.field.expression.FieldExpression;
 import com.cronutils.model.field.expression.On;
-import com.google.common.collect.Lists;
-import org.apache.commons.lang3.Validate;
+import com.cronutils.utils.Preconditions;
+import java.util.ArrayList;
 
 import java.time.DayOfWeek;
 import java.time.LocalDate;
@@ -29,7 +29,7 @@ class OnDayOfMonthValueGenerator extends FieldValueGenerator {
 
     public OnDayOfMonthValueGenerator(CronField cronField, int year, int month) {
         super(cronField);
-        Validate.isTrue(CronFieldName.DAY_OF_MONTH.equals(cronField.getField()), "CronField does not belong to day of" +
+        Preconditions.checkArgument(CronFieldName.DAY_OF_MONTH.equals(cronField.getField()), "CronField does not belong to day of" +
                 " month");
         this.year = year;
         this.month = month;
@@ -58,7 +58,7 @@ class OnDayOfMonthValueGenerator extends FieldValueGenerator {
 
     @Override
     protected List<Integer> generateCandidatesNotIncludingIntervalExtremes(int start, int end) {
-        List<Integer> values = Lists.newArrayList();
+        List<Integer> values = new ArrayList<>();
         try {
             int reference = generateNextValue(start);
             while (reference < end) {

--- a/src/main/java/com/cronutils/model/time/generator/OnDayOfWeekValueGenerator.java
+++ b/src/main/java/com/cronutils/model/time/generator/OnDayOfWeekValueGenerator.java
@@ -6,8 +6,8 @@ import com.cronutils.model.field.CronField;
 import com.cronutils.model.field.CronFieldName;
 import com.cronutils.model.field.expression.FieldExpression;
 import com.cronutils.model.field.expression.On;
-import com.google.common.collect.Lists;
-import org.apache.commons.lang3.Validate;
+import com.cronutils.utils.Preconditions;
+import java.util.ArrayList;
 
 import java.time.DayOfWeek;
 import java.time.LocalDate;
@@ -31,7 +31,7 @@ class OnDayOfWeekValueGenerator extends FieldValueGenerator {
     
     public OnDayOfWeekValueGenerator(CronField cronField, int year, int month, WeekDay mondayDoWValue) {
         super(cronField);
-        Validate.isTrue(CronFieldName.DAY_OF_WEEK.equals(cronField.getField()), "CronField does not belong to day of week");
+        Preconditions.checkArgument(CronFieldName.DAY_OF_WEEK.equals(cronField.getField()), "CronField does not belong to day of week");
         this.year = year;
         this.month = month;
         this.mondayDoWValue = mondayDoWValue;
@@ -59,7 +59,7 @@ class OnDayOfWeekValueGenerator extends FieldValueGenerator {
 
     @Override
     protected List<Integer> generateCandidatesNotIncludingIntervalExtremes(int start, int end) {
-        List<Integer>values = Lists.newArrayList();
+        List<Integer>values = new ArrayList<>();
         try {
             int reference = generateNextValue(start);
             while(reference<end){

--- a/src/main/java/com/cronutils/model/time/generator/OnFieldValueGenerator.java
+++ b/src/main/java/com/cronutils/model/time/generator/OnFieldValueGenerator.java
@@ -3,7 +3,7 @@ package com.cronutils.model.time.generator;
 import com.cronutils.model.field.CronField;
 import com.cronutils.model.field.expression.FieldExpression;
 import com.cronutils.model.field.expression.On;
-import com.google.common.collect.Lists;
+import java.util.ArrayList;
 
 import java.util.List;
 /*
@@ -43,7 +43,7 @@ class OnFieldValueGenerator extends FieldValueGenerator {
 
     @Override
     protected List<Integer> generateCandidatesNotIncludingIntervalExtremes(int start, int end) {
-        List<Integer> values = Lists.newArrayList();
+        List<Integer> values = new ArrayList<>();
         int time = ((On) cronField.getExpression()).getTime().getValue();
         if(time>start && time<end){
             values.add(time);

--- a/src/main/java/com/cronutils/parser/CronParser.java
+++ b/src/main/java/com/cronutils/parser/CronParser.java
@@ -4,9 +4,9 @@ import com.cronutils.model.Cron;
 import com.cronutils.model.definition.CronDefinition;
 import com.cronutils.model.field.CronField;
 import com.cronutils.model.field.definition.FieldDefinition;
-import com.google.common.collect.Maps;
-import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.lang3.Validate;
+import com.cronutils.utils.Preconditions;
+import com.cronutils.utils.StringUtils;
+import java.util.HashMap;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -32,7 +32,7 @@ import java.util.Map;
  */
 public class CronParser {
 
-	private final Map<Integer, List<CronParserField>> expressions = Maps.newHashMap();;
+	private final Map<Integer, List<CronParserField>> expressions = new HashMap<>();;
 	private CronDefinition cronDefinition;
 
 	/**
@@ -40,7 +40,7 @@ public class CronParser {
 	 *            - cronDefinition of cron expressions to be parsed if null, a NullPointerException will be raised.
 	 */
 	public CronParser(CronDefinition cronDefinition) {
-		this.cronDefinition = Validate.notNull(cronDefinition, "CronDefinition must not be null");
+		this.cronDefinition = Preconditions.checkNotNull(cronDefinition, "CronDefinition must not be null");
 		buildPossibleExpressions(cronDefinition);
 	}
 
@@ -76,7 +76,7 @@ public class CronParser {
 	 *             if expression does not match cron definition
 	 */
 	public Cron parse(String expression) {
-		Validate.notNull(expression, "Expression must not be null");
+		Preconditions.checkNotNull(expression, "Expression must not be null");
 		String replaced = expression.replaceAll("\\s+", " ").trim();
 		if (StringUtils.isEmpty(replaced)) {
 			throw new IllegalArgumentException("Empty expression!");

--- a/src/main/java/com/cronutils/parser/CronParserField.java
+++ b/src/main/java/com/cronutils/parser/CronParserField.java
@@ -15,7 +15,7 @@ package com.cronutils.parser;
 import com.cronutils.model.field.CronField;
 import com.cronutils.model.field.CronFieldName;
 import com.cronutils.model.field.constraint.FieldConstraints;
-import org.apache.commons.lang3.Validate;
+import com.cronutils.utils.Preconditions;
 
 import java.util.Comparator;
 
@@ -35,8 +35,8 @@ public class CronParserField {
 	 *            - CronFieldName instance
 	 */
 	public CronParserField(CronFieldName fieldName, FieldConstraints constraints) {
-		this.field = Validate.notNull(fieldName, "CronFieldName must not be null");
-		this.constraints = Validate.notNull(constraints, "FieldConstraints must not be null");
+		this.field = Preconditions.checkNotNull(fieldName, "CronFieldName must not be null");
+		this.constraints = Preconditions.checkNotNull(constraints, "FieldConstraints must not be null");
 		this.parser = new FieldParser(constraints);
 	}
 

--- a/src/main/java/com/cronutils/parser/FieldParser.java
+++ b/src/main/java/com/cronutils/parser/FieldParser.java
@@ -13,20 +13,31 @@
  */
 package com.cronutils.parser;
 
+import static com.cronutils.model.field.value.SpecialChar.HASH;
+import static com.cronutils.model.field.value.SpecialChar.L;
+import static com.cronutils.model.field.value.SpecialChar.LW;
+import static com.cronutils.model.field.value.SpecialChar.NONE;
+import static com.cronutils.model.field.value.SpecialChar.QUESTION_MARK;
+import static com.cronutils.model.field.value.SpecialChar.W;
+
+import java.util.regex.Pattern;
+
 import com.cronutils.StringValidations;
 import com.cronutils.model.field.constraint.FieldConstraints;
-import com.cronutils.model.field.expression.*;
+import com.cronutils.model.field.expression.Always;
+import com.cronutils.model.field.expression.And;
+import com.cronutils.model.field.expression.Between;
+import com.cronutils.model.field.expression.Every;
+import com.cronutils.model.field.expression.FieldExpression;
+import com.cronutils.model.field.expression.On;
+import com.cronutils.model.field.expression.QuestionMark;
 import com.cronutils.model.field.value.FieldValue;
 import com.cronutils.model.field.value.IntegerFieldValue;
 import com.cronutils.model.field.value.SpecialChar;
 import com.cronutils.model.field.value.SpecialCharFieldValue;
-import com.google.common.annotations.VisibleForTesting;
-import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.lang3.Validate;
-
-import java.util.regex.Pattern;
-
-import static com.cronutils.model.field.value.SpecialChar.*;
+import com.cronutils.utils.Preconditions;
+import com.cronutils.utils.StringUtils;
+import com.cronutils.utils.VisibleForTesting;
 
 /**
  * Parses a field from a cron expression.
@@ -49,7 +60,7 @@ public class FieldParser {
 	private FieldConstraints fieldConstraints;
 
 	public FieldParser(FieldConstraints constraints) {
-		this.fieldConstraints = Validate.notNull(constraints, "FieldConstraints must not be null");
+		this.fieldConstraints = Preconditions.checkNotNull(constraints, "FieldConstraints must not be null");
 	}
 
 	/**

--- a/src/main/java/com/cronutils/utils/Preconditions.java
+++ b/src/main/java/com/cronutils/utils/Preconditions.java
@@ -1,0 +1,271 @@
+/*
+ * Copyright (C) 2007 The Guava Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.cronutils.utils;
+
+import java.util.Collection;
+
+/**
+ * Static convenience methods that help a method or constructor check whether it was invoked
+ * correctly (whether its <i>preconditions</i> have been met). These methods generally accept a
+ * {@code boolean} expression which is expected to be {@code true} (or in the case of {@code
+ * checkNotNull}, an object reference which is expected to be non-null). When {@code false} (or
+ * {@code null}) is passed instead, the {@code Preconditions} method throws an unchecked exception,
+ * which helps the calling method communicate to <i>its</i> caller that <i>that</i> caller has made
+ * a mistake. Example: <pre>   {@code
+ *
+ *   /**
+ *    * Returns the positive square root of the given value.
+ *    *
+ *    * @throws IllegalArgumentException if the value is negative
+ *    *}{@code /
+ *   public static double sqrt(double value) {
+ *     Preconditions.checkArgument(value >= 0.0, "negative value: %s", value);
+ *     // calculate the square root
+ *   }
+ *
+ *   void exampleBadCaller() {
+ *     double d = sqrt(-1.0);
+ *   }}</pre>
+ *
+ * In this example, {@code checkArgument} throws an {@code IllegalArgumentException} to indicate
+ * that {@code exampleBadCaller} made an error in <i>its</i> call to {@code sqrt}.
+ *
+ * <h3>Warning about performance</h3>
+ *
+ * <p>The goal of this class is to improve readability of code, but in some circumstances this may
+ * come at a significant performance cost. Remember that parameter values for message construction
+ * must all be computed eagerly, and autoboxing and varargs array creation may happen as well, even
+ * when the precondition check then succeeds (as it should almost always do in production). In some
+ * circumstances these wasted CPU cycles and allocations can add up to a real problem.
+ * Performance-sensitive precondition checks can always be converted to the customary form:
+ * <pre>   {@code
+ *
+ *   if (value < 0.0) {
+ *     throw new IllegalArgumentException("negative value: " + value);
+ *   }}</pre>
+ *
+ * <h3>Other types of preconditions</h3>
+ *
+ * <p>Not every type of precondition failure is supported by these methods. Continue to throw
+ * standard JDK exceptions such as {@link java.util.NoSuchElementException} or {@link
+ * UnsupportedOperationException} in the situations they are intended for.
+ *
+ * <h3>Non-preconditions</h3>
+ *
+ * <p>It is of course possible to use the methods of this class to check for invalid conditions
+ * which are <i>not the caller's fault</i>. Doing so is <b>not recommended</b> because it is
+ * misleading to future readers of the code and of stack traces. See
+ * <a href="http://code.google.com/p/guava-libraries/wiki/ConditionalFailuresExplained">Conditional
+ * failures explained</a> in the Guava User Guide for more advice.
+ *
+ * <h3>{@code java.util.Objects.requireNonNull()}</h3>
+ *
+ * <p>Projects which use {@code com.google.common} should generally avoid the use of {@link
+ * java.util.Objects#requireNonNull(Object)}. Instead, use whichever of {@link
+ * #checkNotNull(Object)} or Verify#verifyNotNull(Object) is appropriate to the situation.
+ * (The same goes for the message-accepting overloads.)
+ *
+ * <h3>Only {@code %s} is supported</h3>
+ *
+ * <p>In {@code Preconditions} error message template strings, only the {@code "%s"} specifier is
+ * supported, not the full range of {@link java.util.Formatter} specifiers.
+ *
+ * <h3>More information</h3>
+ *
+ * <p>See the Guava User Guide on
+ * <a href="http://code.google.com/p/guava-libraries/wiki/PreconditionsExplained">using {@code
+ * Preconditions}</a>.
+ *
+ * @author Kevin Bourrillion
+ * @since 2.0 (imported from Google Collections Library)
+ */
+public class Preconditions {
+  private Preconditions() {}
+
+  /**
+   * Ensures the truth of an expression involving one or more parameters to the calling method.
+   *
+   * @param expression a boolean expression
+   * @param errorMessage the exception message to use if the check fails; will be converted to a
+   *     string using {@link String#valueOf(Object)}
+   * @throws IllegalArgumentException if {@code expression} is false
+   */
+  public static void checkArgument(boolean expression, Object errorMessage) {
+    if (!expression) {
+      throw new IllegalArgumentException(String.valueOf(errorMessage));
+    }
+  }
+
+  /**
+   * Ensures the truth of an expression involving one or more parameters to the calling method.
+   *
+   * @param expression a boolean expression
+   * @param errorMessageTemplate a template for the exception message should the check fail. The
+   *     message is formed by replacing each {@code %s} placeholder in the template with an
+   *     argument. These are matched by position - the first {@code %s} gets {@code
+   *     errorMessageArgs[0]}, etc.  Unmatched arguments will be appended to the formatted message
+   *     in square braces. Unmatched placeholders will be left as-is.
+   * @param errorMessageArgs the arguments to be substituted into the message template. Arguments
+   *     are converted to strings using {@link String#valueOf(Object)}.
+   * @throws IllegalArgumentException if {@code expression} is false
+   * @throws NullPointerException if the check fails and either {@code errorMessageTemplate} or
+   *     {@code errorMessageArgs} is null (don't let this happen)
+   */
+  public static void checkArgument(boolean expression,
+      String errorMessageTemplate,
+      Object... errorMessageArgs) {
+    if (!expression) {
+      throw new IllegalArgumentException(format(errorMessageTemplate, errorMessageArgs));
+    }
+  }
+
+  /**
+   * Ensures the truth of an expression involving the state of the calling instance, but not
+   * involving any parameters to the calling method.
+   *
+   * @param expression a boolean expression
+   * @param errorMessageTemplate a template for the exception message should the check fail. The
+   *     message is formed by replacing each {@code %s} placeholder in the template with an
+   *     argument. These are matched by position - the first {@code %s} gets {@code
+   *     errorMessageArgs[0]}, etc.  Unmatched arguments will be appended to the formatted message
+   *     in square braces. Unmatched placeholders will be left as-is.
+   * @param errorMessageArgs the arguments to be substituted into the message template. Arguments
+   *     are converted to strings using {@link String#valueOf(Object)}.
+   * @throws IllegalStateException if {@code expression} is false
+   * @throws NullPointerException if the check fails and either {@code errorMessageTemplate} or
+   *     {@code errorMessageArgs} is null (don't let this happen)
+   */
+  public static void checkState(boolean expression,
+      String errorMessageTemplate,
+      Object... errorMessageArgs) {
+    if (!expression) {
+      throw new IllegalStateException(format(errorMessageTemplate, errorMessageArgs));
+    }
+  }
+
+  /**
+   * Ensures that an object reference passed as a parameter to the calling method is not null.
+   *
+   * @param reference an object reference
+   * @return the non-null reference that was validated
+   * @throws NullPointerException if {@code reference} is null
+   */
+  public static <T> T checkNotNull(T reference) {
+    if (reference == null) {
+      throw new NullPointerException();
+    }
+    return reference;
+  }
+
+  /**
+   * Ensures that an object reference passed as a parameter to the calling method is not null.
+   *
+   * @param reference an object reference
+   * @param errorMessage the exception message to use if the check fails; will be converted to a
+   *     string using {@link String#valueOf(Object)}
+   * @return the non-null reference that was validated
+   * @throws NullPointerException if {@code reference} is null
+   */
+  public static <T> T checkNotNull(T reference, Object errorMessage) {
+    if (reference == null) {
+      throw new NullPointerException(String.valueOf(errorMessage));
+    }
+    return reference;
+  }
+
+  /**
+   * Ensures that a string reference passed as a parameter to the calling method is not null
+   * nor empty.
+   *
+   * @param reference a string reference
+   * @param errorMessage the exception message to use if the check fails; will be converted to a
+   *     string using {@link String#valueOf(Object)}
+   * @return the non-null reference that was validated
+   * @throws NullPointerException if {@code reference} is null
+   * @throws IllegalArgumentException if {@code reference} is empty
+   */
+  public static String checkNotNullNorEmpty(String reference, Object errorMessage) {
+    if (reference == null) {
+      throw new NullPointerException(String.valueOf(errorMessage));
+    }
+    if (reference.isEmpty()) {
+      throw new IllegalArgumentException(String.valueOf(errorMessage));
+    }
+    return reference;
+  }
+
+  /**
+   * Ensures that a collection reference passed as a parameter to the calling method is not null
+   * nor empty.
+   *
+   * @param reference a collection reference
+   * @param errorMessage the exception message to use if the check fails; will be converted to a
+   *     string using {@link String#valueOf(Object)}
+   * @return the non-null reference that was validated
+   * @throws NullPointerException if {@code reference} is null
+   * @throws IllegalArgumentException if {@code reference} is empty
+   */
+  public static <T extends Collection<?>> T checkNotNullNorEmpty(T reference, Object errorMessage) {
+    if (reference == null) {
+      throw new NullPointerException(String.valueOf(errorMessage));
+    }
+    if (reference.isEmpty()) {
+      throw new IllegalArgumentException(String.valueOf(errorMessage));
+    }
+    return reference;
+  }
+
+  /**
+   * Substitutes each {@code %s} in {@code template} with an argument. These are matched by
+   * position: the first {@code %s} gets {@code args[0]}, etc.  If there are more arguments than
+   * placeholders, the unmatched arguments will be appended to the end of the formatted message in
+   * square braces.
+   *
+   * @param template a non-null string containing 0 or more {@code %s} placeholders.
+   * @param args the arguments to be substituted into the message template. Arguments are converted
+   *     to strings using {@link String#valueOf(Object)}. Arguments can be null.
+   */
+  // Note that this is somewhat-improperly used from Verify.java as well.
+  static String format(String template, Object... args) {
+    template = String.valueOf(template); // null -> "null"
+
+    // start substituting the arguments into the '%s' placeholders
+    StringBuilder builder = new StringBuilder(template.length() + 16 * args.length);
+    int templateStart = 0;
+    int i = 0;
+    while (i < args.length) {
+      int placeholderStart = template.indexOf("%s", templateStart);
+      if (placeholderStart == -1) {
+        break;
+      }
+      builder.append(template.substring(templateStart, placeholderStart));
+      builder.append(args[i++]);
+      templateStart = placeholderStart + 2;
+    }
+    builder.append(template.substring(templateStart));
+
+    // if we run out of placeholders, append the extra args in square braces
+    if (i < args.length) {
+      builder.append(" [");
+      builder.append(args[i++]);
+      while (i < args.length) {
+        builder.append(", ");
+        builder.append(args[i++]);
+      }
+      builder.append(']');
+    }
+
+    return builder.toString();
+  }
+}

--- a/src/main/java/com/cronutils/utils/Preconditions.java
+++ b/src/main/java/com/cronutils/utils/Preconditions.java
@@ -237,8 +237,8 @@ public class Preconditions {
    *     to strings using {@link String#valueOf(Object)}. Arguments can be null.
    */
   // Note that this is somewhat-improperly used from Verify.java as well.
-  static String format(String template, Object... args) {
-    template = String.valueOf(template); // null -> "null"
+  private static String format(String nullableTemplate, Object... args) {
+    String template = String.valueOf(nullableTemplate); // null -> "null"
 
     // start substituting the arguments into the '%s' placeholders
     StringBuilder builder = new StringBuilder(template.length() + 16 * args.length);

--- a/src/main/java/com/cronutils/utils/StringUtils.java
+++ b/src/main/java/com/cronutils/utils/StringUtils.java
@@ -1,0 +1,142 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.cronutils.utils;
+
+/**
+ * <p>Operations on {@link java.lang.String} that are
+ * {@code null} safe.</p>
+ *
+ * <ul>
+ *  <li><b>IsEmpty</b>
+ *      - checks if a String contains text</li>
+ *  <li><b>IndexOfAny</b>
+ *      - index-of any of a set of Strings</li>
+ * </ul>
+ *
+ * <p>The {@code StringUtils} class defines certain words related to
+ * String handling.</p>
+ *
+ * <ul>
+ *  <li>null - {@code null}</li>
+ *  <li>empty - a zero-length string ({@code ""})</li>
+ *  <li>space - the space character ({@code ' '}, char 32)</li>
+ *  <li>whitespace - the characters defined by {@link Character#isWhitespace(char)}</li>
+ *  <li>trim - the characters &lt;= 32 as in {@link String#trim()}</li>
+ * </ul>
+ *
+ * <p>{@code StringUtils} handles {@code null} input Strings quietly.
+ * That is to say that a {@code null} input will return {@code null}.
+ * Where a {@code boolean} or {@code int} is being returned
+ * details vary by method.</p>
+ *
+ * <p>A side effect of the {@code null} handling is that a
+ * {@code NullPointerException} should be considered a bug in
+ * {@code StringUtils}.</p>
+ *
+ * <p>Methods in this class give sample code to explain their operation.
+ * The symbol {@code *} is used to indicate any input including {@code null}.</p>
+ *
+ * <p>#ThreadSafe#</p>
+ * @see java.lang.String
+ * @since 1.0
+ * @version $Id: StringUtils.java 1648067 2014-12-27 16:45:42Z britter $
+ */
+//@Immutable
+public class StringUtils {
+  private StringUtils() {}
+
+  // Empty checks
+  //-----------------------------------------------------------------------
+  /**
+   * <p>Checks if a CharSequence is empty ("") or null.</p>
+   *
+   * <pre>
+   * StringUtils.isEmpty(null)      = true
+   * StringUtils.isEmpty("")        = true
+   * StringUtils.isEmpty(" ")       = false
+   * StringUtils.isEmpty("bob")     = false
+   * StringUtils.isEmpty("  bob  ") = false
+   * </pre>
+   *
+   * <p>NOTE: This method changed in Lang version 2.0.
+   * It no longer trims the CharSequence.
+   * That functionality is available in isBlank().</p>
+   *
+   * @param cs  the CharSequence to check, may be null
+   * @return {@code true} if the CharSequence is empty or null
+   * @since 3.0 Changed signature from isEmpty(String) to isEmpty(CharSequence)
+   */
+  public static boolean isEmpty(final CharSequence cs) {
+      return cs == null || cs.length() == 0;
+  }
+
+  // ContainsAny
+  //-----------------------------------------------------------------------
+  /**
+   * <p>Checks if the CharSequence contains any character in the given
+   * set of characters.</p>
+   *
+   * <p>A {@code null} CharSequence will return {@code false}.
+   * A {@code null} or zero length search array will return {@code false}.</p>
+   *
+   * <pre>
+   * StringUtils.containsAny(null, *)                = false
+   * StringUtils.containsAny("", *)                  = false
+   * StringUtils.containsAny(*, null)                = false
+   * StringUtils.containsAny(*, [])                  = false
+   * StringUtils.containsAny("zzabyycdxx",['z','a']) = true
+   * StringUtils.containsAny("zzabyycdxx",['b','y']) = true
+   * StringUtils.containsAny("aba", ['z'])           = false
+   * </pre>
+   *
+   * @param cs  the CharSequence to check, may be null
+   * @param searchChars  the chars to search for, may be null
+   * @return the {@code true} if any of the chars are found,
+   * {@code false} if no match or null input
+   * @since 2.4
+   * @since 3.0 Changed signature from containsAny(String, char[]) to containsAny(CharSequence, char...)
+   */
+  public static boolean containsAny(final CharSequence cs, final char... searchChars) {
+      if (isEmpty(cs) || searchChars == null || searchChars.length == 0) {
+          return false;
+      }
+      final int csLength = cs.length();
+      final int searchLength = searchChars.length;
+      final int csLast = csLength - 1;
+      final int searchLast = searchLength - 1;
+      for (int i = 0; i < csLength; i++) {
+          final char ch = cs.charAt(i);
+          for (int j = 0; j < searchLength; j++) {
+              if (searchChars[j] == ch) {
+                  if (Character.isHighSurrogate(ch)) {
+                      if (j == searchLast) {
+                          // missing low surrogate, fine, like String.indexOf(String)
+                          return true;
+                      }
+                      if (i < csLast && searchChars[j + 1] == cs.charAt(i + 1)) {
+                          return true;
+                      }
+                  } else {
+                      // ch is in the Basic Multilingual Plane
+                      return true;
+                  }
+              }
+          }
+      }
+      return false;
+  }
+}

--- a/src/main/java/com/cronutils/utils/VisibleForTesting.java
+++ b/src/main/java/com/cronutils/utils/VisibleForTesting.java
@@ -1,30 +1,26 @@
-package com.cronutils.model.field.value;
-
-import com.cronutils.utils.Preconditions;
-
 /*
- * Copyright 2015 jmrozanec
+ * Copyright (C) 2006 The Guava Authors
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-public class SpecialCharFieldValue extends FieldValue<SpecialChar> {
-    private SpecialChar specialChar = SpecialChar.NONE;
 
-    public SpecialCharFieldValue(SpecialChar specialChar){
-        Preconditions.checkNotNull(specialChar, "special char must not be null");
-        this.specialChar = specialChar;
-    }
+package com.cronutils.utils;
 
-    @Override
-    public SpecialChar getValue() {
-        return specialChar;
-    }
+/**
+ * Annotates a program element that exists, or is more widely visible than
+ * otherwise necessary, only for use in test code.
+ *
+ * @author Johannes Henkel
+ */
+public @interface VisibleForTesting {
 }
-


### PR DESCRIPTION
I have imported into the project:

- part of Preconditions from guava,
- part of StringUtils from commons lang,
- the VisibleForTesting annotation from guava.

Since guava and commons lang are licensed under ASF (as cron-utils), it shouldn't be a problem.
For each of these 3 files, I have also included the license block from their respective libraries.

In the Predconditions class from guava, I have added 2 new methods called checkNotNullNorEmpty to ensure that a string and a collection won't be null or empty. These methods are compliant with Validate.notEmpty previously used from commons lang. 