### PR TITLE
Minor FieldValueGeneratorFactory refactoring

### DIFF
--- a/src/main/java/com/cronutils/model/time/generator/FieldValueGeneratorFactory.java
+++ b/src/main/java/com/cronutils/model/time/generator/FieldValueGeneratorFactory.java
@@ -18,12 +18,7 @@ import com.cronutils.model.field.value.SpecialChar;
  * limitations under the License.
  */
 public class FieldValueGeneratorFactory {
-    private static FieldValueGeneratorFactory factory = new FieldValueGeneratorFactory();
     private FieldValueGeneratorFactory(){}
-
-    public static FieldValueGeneratorFactory instance(){
-        return factory;
-    }
 
     public static FieldValueGenerator forCronField(CronField cronField){
         FieldExpression fieldExpression = cronField.getExpression();

--- a/src/test/java/com/cronutils/model/time/generator/FieldValueGeneratorFactoryTest.java
+++ b/src/test/java/com/cronutils/model/time/generator/FieldValueGeneratorFactoryTest.java
@@ -26,30 +26,22 @@ import static org.mockito.Mockito.when;
  * limitations under the License.
  */
 public class FieldValueGeneratorFactoryTest {
-    private FieldValueGeneratorFactory fieldValueGeneratorFactory;
-
     private CronField mockCronField;
     @Before
     public void setUp() throws Exception {
-        fieldValueGeneratorFactory = FieldValueGeneratorFactory.instance();
         mockCronField = mock(CronField.class);
-    }
-
-    @Test
-    public void testInstance() throws Exception {
-        assertNotNull(FieldValueGeneratorFactory.instance());
     }
 
     @Test
     public void testForCronFieldAlways() throws Exception {
         when(mockCronField.getExpression()).thenReturn(mock(Always.class));
-        assertEquals(AlwaysFieldValueGenerator.class, fieldValueGeneratorFactory.forCronField(mockCronField).getClass());
+        assertEquals(AlwaysFieldValueGenerator.class, FieldValueGeneratorFactory.forCronField(mockCronField).getClass());
     }
 
     @Test
     public void testForCronFieldAnd() throws Exception {
         when(mockCronField.getExpression()).thenReturn(mock(And.class));
-        assertEquals(AndFieldValueGenerator.class, fieldValueGeneratorFactory.forCronField(mockCronField).getClass());
+        assertEquals(AndFieldValueGenerator.class, FieldValueGeneratorFactory.forCronField(mockCronField).getClass());
     }
 
     @Test


### PR DESCRIPTION
`FieldValueGeneratorFactory` has a `factory` field holding singleton instance of this class. But since this class has no state and only static methods, this instance, along with its getter method, is unnecessary. I'd like to suggest removing it entirely.