### PR TITLE
add a test case for month end 

### DIFF
--- a/src/test/java/com/cronutils/model/time/ExecutionTimeQuartzIntegrationTest.java
+++ b/src/test/java/com/cronutils/model/time/ExecutionTimeQuartzIntegrationTest.java
@@ -412,7 +412,7 @@ public class ExecutionTimeQuartzIntegrationTest {
      * nexExecution()
      * throw exceptions when DAY-OF-MONTH field bigger than param month length
      */
-    @Test
+    @Test(expected = java.lang.IllegalArgumentException.class)
     public void bigNumbersOnDayOfMonthField(){
         Cron cron = parser.parse("0 0 0 31 * ?");
         ExecutionTime executionTime = ExecutionTime.forCron(cron);

--- a/src/test/java/com/cronutils/model/time/ExecutionTimeQuartzIntegrationTest.java
+++ b/src/test/java/com/cronutils/model/time/ExecutionTimeQuartzIntegrationTest.java
@@ -407,7 +407,23 @@ public class ExecutionTimeQuartzIntegrationTest {
 
         assertEquals(ZonedDateTime.of(2016, 8, 31, 0, 0, 0,0, ZoneId.of("UTC")), nextRun);
     }
-    
+
+    /**
+     * nexExecution()
+     * throw exceptions when DAY-OF-MONTH field bigger than param month length
+     */
+    @Test
+    public void bigNumbersOnDayOfMonthField(){
+        Cron cron = parser.parse("0 0 0 31 * ?");
+        ExecutionTime executionTime = ExecutionTime.forCron(cron);
+        ZonedDateTime now = ZonedDateTime.of(2016, 11, 1, 0, 0, 0, 0, ZoneId.of("UTC"));
+
+        //nextRun expected to be  2016-12-31 00:00:00 000
+        //quartz-2.2.3 return the right date
+        ZonedDateTime nextRun = executionTime.nextExecution(now);
+
+        assertEquals(ZonedDateTime.of(2016, 12, 31, 0, 0, 0, 0, ZoneId.of("UTC")), nextRun);
+    }
     @Test
     public void noSpecificDayOfMonthEvaluatedOnLastDay() {
     	Cron cron = parser.parse("0 * * ? * *");


### PR DESCRIPTION
cron like "0 0 0 31 * ?" will cause executionTime.lastExecution(zonedDateTime) throw an exception when  zonedDateTime.getDayOfMonth() less than 31, just like current month.
thanks.
