### PR TITLE
Issues #114 Use the CronDefintion to map to the DayOfWeek description

### DIFF
--- a/src/main/java/com/cronutils/descriptor/CronDescriptor.java
+++ b/src/main/java/com/cronutils/descriptor/CronDescriptor.java
@@ -3,6 +3,7 @@ package com.cronutils.descriptor;
 import com.cronutils.model.Cron;
 import com.cronutils.model.field.CronField;
 import com.cronutils.model.field.CronFieldName;
+import com.cronutils.model.field.definition.FieldDefinition;
 import com.cronutils.utils.Preconditions;
 
 import java.util.Locale;
@@ -55,12 +56,14 @@ public class CronDescriptor {
     public String describe(Cron cron) {
         Preconditions.checkNotNull(cron, "Cron must not be null");
         Map<CronFieldName, CronField> expressions = cron.retrieveFieldsAsMap();
+        Map<CronFieldName, FieldDefinition> fieldDefinitions = cron.getCronDefinition().retrieveFieldDefinitionsAsMap();
+        
         return
                 new StringBuilder()
                         .append(describeHHmmss(expressions)).append(" ")
                         .append(describeDayOfMonth(expressions)).append(" ")
                         .append(describeMonth(expressions)).append(" ")
-                        .append(describeDayOfWeek(expressions)).append(" ")
+                        .append(describeDayOfWeek(expressions, fieldDefinitions)).append(" ")
                         .append(describeYear(expressions))
                         .toString().replaceAll("\\s+", " ").trim();
     }
@@ -117,10 +120,12 @@ public class CronDescriptor {
      * @param fields - fields to describe;
      * @return description - String
      */
-    private String describeDayOfWeek(Map<CronFieldName, CronField> fields) {
+    private String describeDayOfWeek(Map<CronFieldName, CronField> fields, Map<CronFieldName, FieldDefinition> definitions) {
+    	
         String description = DescriptionStrategyFactory.daysOfWeekInstance(
 		        bundle,
-		        fields.containsKey(CronFieldName.DAY_OF_WEEK) ? fields.get(CronFieldName.DAY_OF_WEEK).getExpression() : null
+		        fields.containsKey(CronFieldName.DAY_OF_WEEK) ? fields.get(CronFieldName.DAY_OF_WEEK).getExpression() : null,
+		        definitions.containsKey(CronFieldName.DAY_OF_WEEK) ? definitions.get(CronFieldName.DAY_OF_WEEK) : null 
 		).describe();
 		return this.addExpressions(description, bundle.getString("day"), bundle.getString("days"));
     }

--- a/src/main/java/com/cronutils/descriptor/DescriptionStrategyFactory.java
+++ b/src/main/java/com/cronutils/descriptor/DescriptionStrategyFactory.java
@@ -1,5 +1,8 @@
 package com.cronutils.descriptor;
 
+import com.cronutils.mapper.WeekDay;
+import com.cronutils.model.field.definition.DayOfWeekFieldDefinition;
+import com.cronutils.model.field.definition.FieldDefinition;
 import com.cronutils.model.field.expression.FieldExpression;
 import com.cronutils.model.field.expression.On;
 
@@ -31,9 +34,13 @@ class DescriptionStrategyFactory {
      * @param expression - CronFieldExpression
      * @return - DescriptionStrategy instance, never null
      */
-    public static DescriptionStrategy daysOfWeekInstance(final ResourceBundle bundle, final FieldExpression expression) {
-        final Function<Integer, String> nominal = integer -> DayOfWeek.of(integer).getDisplayName(TextStyle.FULL, bundle.getLocale());
-
+    public static DescriptionStrategy daysOfWeekInstance(final ResourceBundle bundle, final FieldExpression expression, final FieldDefinition definition) {
+        
+    	final Function<Integer, String> nominal = integer -> {
+    		int diff = definition instanceof DayOfWeekFieldDefinition ? DayOfWeek.MONDAY.getValue() - ((DayOfWeekFieldDefinition) definition).getMondayDoWValue().getMondayDoWValue() : 0;
+        	return DayOfWeek.of(integer + diff < 1 ? 7 : integer + diff).getDisplayName(TextStyle.FULL, bundle.getLocale());
+        };
+        
         NominalDescriptionStrategy dow = new NominalDescriptionStrategy(bundle, nominal, expression);
 
         dow.addDescription(fieldExpression -> {

--- a/src/main/java/com/cronutils/model/definition/CronDefinition.java
+++ b/src/main/java/com/cronutils/model/definition/CronDefinition.java
@@ -1,10 +1,15 @@
 package com.cronutils.model.definition;
 
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
 import com.cronutils.model.field.CronFieldName;
 import com.cronutils.model.field.definition.FieldDefinition;
 import com.cronutils.utils.Preconditions;
-
-import java.util.*;
 
 /*
  * Copyright 2014 jmrozanec
@@ -75,6 +80,14 @@ public class CronDefinition {
         return new HashSet<FieldDefinition>(fieldDefinitions.values());
     }
 
+    /**
+     * Retrieve all cron field definitions values as map
+     * @return unmodifiable Map with key CronFieldName and values FieldDefinition, never null
+     */
+    public Map<CronFieldName, FieldDefinition> retrieveFieldDefinitionsAsMap(){
+        return Collections.unmodifiableMap(this.fieldDefinitions);
+    }
+    
     /**
      * Returns field definition for field name of this cron
      * @param cronFieldName cron field name


### PR DESCRIPTION
The Quartz definition uses a Monday value of 2 whilst the java.util.DayOfWeek class used starts with a Monday of 1 which causes the description to be incorrect, i.e. Monday becomes Tuesday and so forth. The fix is to use the field definition from the Cron expession to map back to the DayOfWeek enumeration to rectivfy the issue.

```
public static DescriptionStrategy daysOfWeekInstance(final ResourceBundle bundle, final FieldExpression expression, final FieldDefinition definition) {
        
    	final Function<Integer, String> nominal = integer -> {
    		int diff = definition instanceof DayOfWeekFieldDefinition ? DayOfWeek.MONDAY.getValue() - ((DayOfWeekFieldDefinition) definition).getMondayDoWValue().getMondayDoWValue() : 0;
        	return DayOfWeek.of(integer + diff < 1 ? 7 : integer + diff).getDisplayName(TextStyle.FULL, bundle.getLocale());
        };
        
        NominalDescriptionStrategy dow = new NominalDescriptionStrategy(bundle, nominal, expression);

        dow.addDescription(fieldExpression -> {
            if (fieldExpression instanceof On) {
                On on = (On) fieldExpression;
                switch (on.getSpecialChar().getValue()) {
                    case HASH:
                        return String.format("%s %s %s ", nominal.apply(on.getTime().getValue()), on.getNth(), bundle.getString("of_every_month"));
                    case L:
                        return String.format("%s %s %s ", bundle.getString("last"), nominal.apply(on.getTime().getValue()), bundle.getString("of_every_month"));
                    default:
                        return "";
                }
            }
            return "";
        });
        return dow;
    }
```