### PR TITLE
com.cronutils.model.Cron and all members should be serializable

### DIFF
--- a/src/main/java/com/cronutils/mapper/WeekDay.java
+++ b/src/main/java/com/cronutils/mapper/WeekDay.java
@@ -3,6 +3,7 @@ package com.cronutils.mapper;
 import com.cronutils.utils.Preconditions;
 import com.cronutils.utils.VisibleForTesting;
 
+import java.io.Serializable;
 import java.util.function.Function;
 
 /*
@@ -18,7 +19,7 @@ import java.util.function.Function;
  * limitations under the License.
  */
 @VisibleForTesting
-public class WeekDay {
+public class WeekDay implements Serializable {
     private int mondayDoWValue;
     private boolean firstDayZero;
 

--- a/src/main/java/com/cronutils/model/Cron.java
+++ b/src/main/java/com/cronutils/model/Cron.java
@@ -21,12 +21,13 @@ import com.cronutils.model.field.CronFieldName;
 import com.cronutils.model.field.expression.visitor.ValidationFieldExpressionVisitor;
 import com.cronutils.utils.Preconditions;
 
+import java.io.Serializable;
 import java.util.*;
 
 /**
  * Represents a cron expression
  */
-public class Cron {
+public class Cron implements Serializable {
     private CronDefinition cronDefinition;
     private Map<CronFieldName, CronField> fields;
     private String asString;

--- a/src/main/java/com/cronutils/model/definition/CronConstraint.java
+++ b/src/main/java/com/cronutils/model/definition/CronConstraint.java
@@ -14,7 +14,9 @@ package com.cronutils.model.definition;
 
 import com.cronutils.model.Cron;
 
-public abstract class CronConstraint {
+import java.io.Serializable;
+
+public abstract class CronConstraint implements Serializable {
     private String description;
 
     public CronConstraint(String description){

--- a/src/main/java/com/cronutils/model/definition/CronDefinition.java
+++ b/src/main/java/com/cronutils/model/definition/CronDefinition.java
@@ -1,5 +1,6 @@
 package com.cronutils.model.definition;
 
+import java.io.Serializable;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -27,7 +28,7 @@ import com.cronutils.utils.Preconditions;
 /**
  * Defines fields and conditions over each field for a cron
  */
-public class CronDefinition {
+public class CronDefinition implements Serializable {
     private Map<CronFieldName, FieldDefinition> fieldDefinitions;
     private Set<CronConstraint> cronConstraints;
     private boolean lastFieldOptional;

--- a/src/main/java/com/cronutils/model/field/CronField.java
+++ b/src/main/java/com/cronutils/model/field/CronField.java
@@ -4,6 +4,7 @@ import com.cronutils.model.field.constraint.FieldConstraints;
 import com.cronutils.model.field.expression.FieldExpression;
 import com.cronutils.utils.Preconditions;
 
+import java.io.Serializable;
 import java.util.Comparator;
 
 /*
@@ -18,7 +19,7 @@ import java.util.Comparator;
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-public class CronField {
+public class CronField implements Serializable {
     private CronFieldName field;
     private FieldExpression expression;
     private FieldConstraints constraints;

--- a/src/main/java/com/cronutils/model/field/constraint/FieldConstraints.java
+++ b/src/main/java/com/cronutils/model/field/constraint/FieldConstraints.java
@@ -3,6 +3,7 @@ package com.cronutils.model.field.constraint;
 import com.cronutils.model.field.value.SpecialChar;
 import com.cronutils.utils.Preconditions;
 
+import java.io.Serializable;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
@@ -25,7 +26,7 @@ import java.util.Set;
  * values: int range, valid special characters, valid nominal values. Example for mappings: conversions from nominal values to integers and
  * integer-integer mappings if more than one integer represents the same concept.
  */
-public class FieldConstraints {
+public class FieldConstraints implements Serializable {
 
 	private final Map<String, Integer> stringMapping;
 	private final Map<Integer, Integer> intMapping;

--- a/src/main/java/com/cronutils/model/field/definition/FieldDefinition.java
+++ b/src/main/java/com/cronutils/model/field/definition/FieldDefinition.java
@@ -17,12 +17,13 @@ import com.cronutils.model.field.CronFieldName;
 import com.cronutils.model.field.constraint.FieldConstraints;
 import com.cronutils.utils.Preconditions;
 
+import java.io.Serializable;
 import java.util.Comparator;
 
 /**
  * Represents a definition of allowed values for a cron field.
  */
-public class FieldDefinition {
+public class FieldDefinition implements Serializable {
     private CronFieldName fieldName;
     private FieldConstraints constraints;
 

--- a/src/main/java/com/cronutils/model/field/expression/FieldExpression.java
+++ b/src/main/java/com/cronutils/model/field/expression/FieldExpression.java
@@ -1,5 +1,7 @@
 package com.cronutils.model.field.expression;
 
+import java.io.Serializable;
+
 import com.cronutils.model.field.expression.visitor.FieldExpressionVisitor;
 import com.cronutils.utils.Preconditions;
 
@@ -16,9 +18,9 @@ import com.cronutils.utils.Preconditions;
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-public abstract class FieldExpression {
+public abstract class FieldExpression implements Serializable {
 
-	public And and(FieldExpression exp) {
+    public And and(FieldExpression exp) {
 		return new And().and(this).and(exp);
 	}
 

--- a/src/main/java/com/cronutils/model/field/value/FieldValue.java
+++ b/src/main/java/com/cronutils/model/field/value/FieldValue.java
@@ -1,5 +1,7 @@
 package com.cronutils.model.field.value;
 
+import java.io.Serializable;
+
 /*
  * Copyright 2015 jmrozanec
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -18,7 +20,8 @@ package com.cronutils.model.field.value;
  * manipulate different types of values in a homogeneous way
  * @param <T>
  */
-public abstract class FieldValue<T> {
+public abstract class FieldValue<T extends Serializable>  implements Serializable {
+    
     /**
      * Allows to obtain the value
      * @return some value, never null


### PR DESCRIPTION
It's currently not possible to use com.cronutils.model.Cron as a member type in domain objects when using serialization-heavy frameworks like Apache Wicket.

This commit adds the java.io.Serializable interface to all direct  and indirect children of com.cronutils.model.Cron. I intentionally did not add an explicit serialVersionUID field to these classes since nobody (including me) remembers all the binary compatibility rules  (see https://wiki.eclipse.org/Evolving_Java-based_APIs_2) so maintaining this value is best left to the compiler. 

Maintenance-wise , I would probably add a disclaimer to the documentation stating that binary compatibility between versions is best-effort and breakage may occur (=so using Java serialization for long-term storage of these classes may be a bad idea).  
I have to admit that in my special use-case (Apache Wicket), the serialized data is only held in-memory for a very short time (seconds to minutes) so I don't care too much about this... YMMV.