### PR TITLE
Improved handling of optional cron expression fields.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ nb-build.xml
 nbproject
 *.sh
 zrefactor
+/bin/

--- a/src/main/java/com/cronutils/model/definition/CronDefinition.java
+++ b/src/main/java/com/cronutils/model/definition/CronDefinition.java
@@ -25,7 +25,6 @@ import java.util.*;
 public class CronDefinition {
     private Map<CronFieldName, FieldDefinition> fieldDefinitions;
     private Set<CronConstraint> cronConstraints;
-    private boolean lastFieldOptional;
     private boolean strictRanges;
 
     /**
@@ -35,28 +34,17 @@ public class CronDefinition {
      *                         Throws an IllegalArgumentException if an empty list is received
      * @param lastFieldOptional - boolean, value stating if last field is optional
      */
-    public CronDefinition(List<FieldDefinition> fieldDefinitions, Set<CronConstraint> cronConstraints, boolean lastFieldOptional, boolean strictRanges){
+    public CronDefinition(List<FieldDefinition> fieldDefinitions, Set<CronConstraint> cronConstraints, boolean strictRanges){
         Preconditions.checkNotNull(fieldDefinitions, "Field definitions must not be null");
         Preconditions.checkNotNull(cronConstraints, "Cron validations must not be null");
         Preconditions.checkNotNullNorEmpty(fieldDefinitions, "Field definitions must not be empty");
-        if(lastFieldOptional){
-            Preconditions.checkArgument(fieldDefinitions.size() > 1, "If last field is optional, field definition must hold at least two fields");
-        }
+        Preconditions.checkArgument(!fieldDefinitions.get(0).isOptional(), "The first field must not be optional");
         this.fieldDefinitions = new HashMap<>();
         for(FieldDefinition field : fieldDefinitions){
             this.fieldDefinitions.put(field.getFieldName(), field);
         }
         this.cronConstraints = Collections.unmodifiableSet(cronConstraints);
-        this.lastFieldOptional = lastFieldOptional;
         this.strictRanges = strictRanges;
-    }
-
-    /**
-     * If last field of a cron expression is optional
-     * @return true if has an optional field, false otherwise.
-     */
-    public boolean isLastFieldOptional() {
-        return lastFieldOptional;
     }
 
     /**

--- a/src/main/java/com/cronutils/model/field/CronFieldName.java
+++ b/src/main/java/com/cronutils/model/field/CronFieldName.java
@@ -17,7 +17,7 @@ package com.cronutils.model.field;
  * Enumerates cron field names
  */
 public enum CronFieldName {
-    SECOND(0), MINUTE(1), HOUR(2), DAY_OF_MONTH(3), MONTH(4), DAY_OF_WEEK(5), YEAR(6);
+    SECOND(0), MINUTE(1), HOUR(2), DAY_OF_MONTH(3), MONTH(4), DAY_OF_WEEK(5), YEAR(6), /*DAY_OF_YEAR(7) /** Similar to DAY_OF_MONTH whose main purpose would be the definition of effective bi-, tri- or quad-weekly schedules via proprietary cron expressions. */;
 
     private int order;
 

--- a/src/main/java/com/cronutils/model/field/definition/DayOfWeekFieldDefinition.java
+++ b/src/main/java/com/cronutils/model/field/definition/DayOfWeekFieldDefinition.java
@@ -24,12 +24,13 @@ public class DayOfWeekFieldDefinition extends FieldDefinition {
      *
      * @param fieldName   - CronFieldName; name of the field
      *                    if null, a NullPointerException will be raised.
+     * @param optional    - optional tag                   
      * @param constraints - FieldConstraints, constraints;
      * @param mondayDoWValue - day of week convention for field
      *
      */
-    public DayOfWeekFieldDefinition(CronFieldName fieldName, FieldConstraints constraints, WeekDay mondayDoWValue) {
-        super(fieldName, constraints);
+    public DayOfWeekFieldDefinition(CronFieldName fieldName, FieldConstraints constraints, boolean optional, WeekDay mondayDoWValue) {
+        super(fieldName, constraints, optional);
         this.mondayDoWValue = mondayDoWValue;
     }
 

--- a/src/main/java/com/cronutils/model/field/definition/FieldDayOfWeekDefinitionBuilder.java
+++ b/src/main/java/com/cronutils/model/field/definition/FieldDayOfWeekDefinitionBuilder.java
@@ -49,7 +49,7 @@ public class FieldDayOfWeekDefinitionBuilder extends FieldSpecialCharsDefinition
      */
     public CronDefinitionBuilder and(){
         boolean zeroInRange = constraints.createConstraintsInstance().isInRange(0);
-        cronDefinitionBuilder.register(new DayOfWeekFieldDefinition(fieldName, constraints.createConstraintsInstance(), new WeekDay(mondayDoWValue, zeroInRange)));
+        cronDefinitionBuilder.register(new DayOfWeekFieldDefinition(fieldName, constraints.createConstraintsInstance(), optional, new WeekDay(mondayDoWValue, zeroInRange)));
         return cronDefinitionBuilder;
     }
 

--- a/src/main/java/com/cronutils/model/field/definition/FieldDefinition.java
+++ b/src/main/java/com/cronutils/model/field/definition/FieldDefinition.java
@@ -25,17 +25,31 @@ import java.util.Comparator;
 public class FieldDefinition {
     private CronFieldName fieldName;
     private FieldConstraints constraints;
+    private final boolean optional;
 
+    /**
+     * Mandatory field Constructor
+     * @param fieldName - CronFieldName; name of the field
+     *                  if null, a NullPointerException will be raised.
+     * @param constraints - FieldConstraints, constraints;
+     *                    if null, a NullPointerException will be raised.
+     */                    
+    public FieldDefinition(CronFieldName fieldName, FieldConstraints constraints){
+        this(fieldName, constraints, false);
+    }
+    
     /**
      * Constructor
      * @param fieldName - CronFieldName; name of the field
      *                  if null, a NullPointerException will be raised.
      * @param constraints - FieldConstraints, constraints;
      *                    if null, a NullPointerException will be raised.
+     * @param optional - if {@code false} the field is mandatory, optional otheriwse.                   
      */
-    public FieldDefinition(CronFieldName fieldName, FieldConstraints constraints){
+    public FieldDefinition(CronFieldName fieldName, FieldConstraints constraints, boolean optional){
         this.fieldName = Preconditions.checkNotNull(fieldName, "CronFieldName must not be null");
         this.constraints = Preconditions.checkNotNull(constraints, "FieldConstraints must not be null");
+        this.optional = optional;
     }
 
     /**
@@ -52,6 +66,14 @@ public class FieldDefinition {
      */
     public FieldConstraints getConstraints() {
         return constraints;
+    }
+    
+    /**
+     * Get optional tag
+     * @return optional tag
+     */
+    public boolean isOptional() {
+        return optional;
     }
 
     /**

--- a/src/main/java/com/cronutils/model/field/definition/FieldDefinitionBuilder.java
+++ b/src/main/java/com/cronutils/model/field/definition/FieldDefinitionBuilder.java
@@ -24,6 +24,7 @@ public class FieldDefinitionBuilder {
     protected CronDefinitionBuilder cronDefinitionBuilder;
     protected final CronFieldName fieldName;
     protected FieldConstraintsBuilder constraints;
+    protected boolean optional;
 
     /**
      * Constructor
@@ -60,13 +61,22 @@ public class FieldDefinitionBuilder {
         constraints.withValidRange(startRange, endRange);
         return this;
     }
+    
+    /**
+     * Allows to tag a field as optional.
+     * @return this instance
+     */
+    public FieldDefinitionBuilder optional(){
+        optional = true;
+        return this;
+    }
 
     /**
      * Registers CronField in ParserDefinitionBuilder and returns its instance
      * @return ParserDefinitionBuilder instance obtained from constructor
      */
     public CronDefinitionBuilder and(){
-        cronDefinitionBuilder.register(new FieldDefinition(fieldName, constraints.createConstraintsInstance()));
+        cronDefinitionBuilder.register(new FieldDefinition(fieldName, constraints.createConstraintsInstance(), optional));
         return cronDefinitionBuilder;
     }
 }

--- a/src/main/java/com/cronutils/parser/CronParserField.java
+++ b/src/main/java/com/cronutils/parser/CronParserField.java
@@ -27,17 +27,35 @@ public class CronParserField {
 	private final CronFieldName field;
 	private final FieldConstraints constraints;
 	private final FieldParser parser;
+	private final boolean optional;
+	
+	/**
+     * Mandatory CronParserField Constructor
+     * 
+     * @param fieldName
+     *            - CronFieldName instance
+     * @param constraints
+     *            - FieldConstraints, constraints
+     */
+    public CronParserField(CronFieldName fieldName, FieldConstraints constraints) {
+        this(fieldName, constraints, false);
+    }
 
 	/**
 	 * Constructor
 	 * 
 	 * @param fieldName
 	 *            - CronFieldName instance
+	 * @param constraints
+	 *            - FieldConstraints, constraints
+	 * @param optional
+	 *            - optional tag
 	 */
-	public CronParserField(CronFieldName fieldName, FieldConstraints constraints) {
+	public CronParserField(CronFieldName fieldName, FieldConstraints constraints, boolean optional) {
 		this.field = Preconditions.checkNotNull(fieldName, "CronFieldName must not be null");
 		this.constraints = Preconditions.checkNotNull(constraints, "FieldConstraints must not be null");
 		this.parser = new FieldParser(constraints);
+		this.optional = optional;
 	}
 
 	/**
@@ -48,6 +66,15 @@ public class CronParserField {
 	public CronFieldName getField() {
 		return field;
 	}
+	
+	/**
+     * Returns optional tag
+     * 
+     * @return optional tag
+     */
+    public final boolean isOptional() {
+        return optional;
+    }
 
 	/**
 	 * Parses a String cron expression

--- a/src/test/java/com/cronutils/Issue55UnexpectedExecutionTimes.java
+++ b/src/test/java/com/cronutils/Issue55UnexpectedExecutionTimes.java
@@ -34,8 +34,7 @@ public class Issue55UnexpectedExecutionTimes {
                 .withDayOfWeek()//Monday=1
                 .withIntMapping(7, 0) //we support non-standard non-zero-based numbers!
                 .supportsHash().supportsL().supportsW().supportsQuestionMark().and()
-                .withYear().and()
-                .lastFieldOptional()
+                .withYear().optional().and()
                 .withCronValidation(
                         //both a day-of-week AND a day-of-month parameter should fail for this case; otherwise returned values are correct
                         new CronConstraint("Both, a day-of-week AND a day-of-month parameter, are not supported.") {

--- a/src/test/java/com/cronutils/model/definition/CronDefinitionBuilderTest.java
+++ b/src/test/java/com/cronutils/model/definition/CronDefinitionBuilderTest.java
@@ -100,7 +100,6 @@ public class CronDefinitionBuilderTest {
     public void testLastFieldOptionalFalseByDefault() throws Exception {
         CronDefinition definition = builder.withHours().and().instance();
         assertNotNull(definition);
-        assertFalse(definition.isLastFieldOptional());
     }
 
     @Test

--- a/src/test/java/com/cronutils/model/definition/CronDefinitionTest.java
+++ b/src/test/java/com/cronutils/model/definition/CronDefinitionTest.java
@@ -27,65 +27,59 @@ import static org.mockito.Mockito.when;
  * limitations under the License.
  */
 public class CronDefinitionTest {
-    private boolean lastFieldOptional;
     private boolean enforceStrictRange;
     private CronFieldName testFieldName1;
     private CronFieldName testFieldName2;
+    private CronFieldName testFieldName3;
     @Mock
     private FieldDefinition mockFieldDefinition1;
     @Mock
     private FieldDefinition mockFieldDefinition2;
+    @Mock
+    private FieldDefinition mockFieldDefinition3optional;
 
     @Before
     public void setUp(){
         testFieldName1 = CronFieldName.SECOND;
         testFieldName2 = CronFieldName.MINUTE;
+        testFieldName3 = CronFieldName.HOUR;
         MockitoAnnotations.initMocks(this);
         when(mockFieldDefinition1.getFieldName()).thenReturn(testFieldName1);
         when(mockFieldDefinition2.getFieldName()).thenReturn(testFieldName2);
+        when(mockFieldDefinition3optional.getFieldName()).thenReturn(testFieldName3);
+        when(mockFieldDefinition3optional.isOptional()).thenReturn(Boolean.TRUE);
 
-        lastFieldOptional = false;
         enforceStrictRange = false;
     }
 
 
     @Test(expected = NullPointerException.class)
     public void testConstructorNullFieldsParameter() throws Exception {
-        new CronDefinition(null, Sets.newHashSet(), lastFieldOptional, enforceStrictRange);
+        new CronDefinition(null, Sets.newHashSet(), enforceStrictRange);
     }
 
     @Test(expected = NullPointerException.class)
     public void testConstructorNullConstraintsParameter() throws Exception {
-        new CronDefinition(Lists.newArrayList(), null, lastFieldOptional, enforceStrictRange);
+        new CronDefinition(Lists.newArrayList(), null, enforceStrictRange);
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void testConstructorEmptyFieldsParameter() throws Exception {
-        new CronDefinition(new ArrayList<>(), Sets.newHashSet(), lastFieldOptional, enforceStrictRange);
-    }
-
-    @Test
-    public void testLastFieldOptionalTrueWhenSet() throws Exception {
-        lastFieldOptional = true;
-        List<FieldDefinition> fields = Lists.newArrayList();
-        fields.add(mockFieldDefinition1);
-        fields.add(mockFieldDefinition2);
-        assertEquals(lastFieldOptional, new CronDefinition(fields, Sets.newHashSet(), lastFieldOptional, enforceStrictRange).isLastFieldOptional());
+        new CronDefinition(new ArrayList<>(), Sets.newHashSet(), enforceStrictRange);
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void testLastFieldOptionalNotAllowedOnSingleFieldDefinition() throws Exception {
-        lastFieldOptional = true;
         List<FieldDefinition> fields = Lists.newArrayList();
-        fields.add(mockFieldDefinition1);
-        new CronDefinition(fields, Sets.newHashSet(), lastFieldOptional, enforceStrictRange).isLastFieldOptional();
+        fields.add(mockFieldDefinition3optional);
+        new CronDefinition(fields, Sets.newHashSet(), enforceStrictRange);
     }
 
     @Test
     public void testGetFieldDefinitions() throws Exception {
         List<FieldDefinition> fields = Lists.newArrayList();
         fields.add(mockFieldDefinition1);
-        CronDefinition cronDefinition = new CronDefinition(fields, Sets.newHashSet(), lastFieldOptional, enforceStrictRange);
+        CronDefinition cronDefinition = new CronDefinition(fields, Sets.newHashSet(), enforceStrictRange);
         assertNotNull(cronDefinition.getFieldDefinitions());
         assertEquals(1, cronDefinition.getFieldDefinitions().size());
         assertTrue(cronDefinition.getFieldDefinitions().contains(mockFieldDefinition1));

--- a/src/test/java/com/cronutils/model/time/ExecutionTimeCustomDefinitionIntegrationTest.java
+++ b/src/test/java/com/cronutils/model/time/ExecutionTimeCustomDefinitionIntegrationTest.java
@@ -131,8 +131,8 @@ public class ExecutionTimeCustomDefinitionIntegrationTest {
                 .withValidRange(1, 7)
                 .supportsHash().supportsL()
                 .and()
-                .withYear().and()
-                .lastFieldOptional().instance();
+                .withYear().optional().and()
+                .instance();
 
         CronParser parser = new CronParser(cronDefinition);
         Cron cron = parser.parse("30 3 * * MON-FRI");


### PR DESCRIPTION
This forms a prerequisite for the introduction of additional proprietary optional
fields, e.g. a missing DAY_OF_YEAR field in the Quartz Cron spec to
allow the definition of effective bi-, tri- or quad-weekly schedules.