### PR TITLE
Unit tests to demonstrate a question about asString representation of…

### DIFF
--- a/src/test/java/com/cronutils/model/field/expression/EveryTest.java
+++ b/src/test/java/com/cronutils/model/field/expression/EveryTest.java
@@ -1,9 +1,10 @@
 package com.cronutils.model.field.expression;
 
-import com.cronutils.model.field.value.IntegerFieldValue;
+import static org.junit.Assert.assertEquals;
+
 import org.junit.Test;
 
-import static org.junit.Assert.assertEquals;
+import com.cronutils.model.field.value.IntegerFieldValue;
 /*
  * Copyright 2015 jmrozanec
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -26,5 +27,10 @@ public class EveryTest {
     @Test
     public void testGetTimeNull() throws Exception {
         assertEquals(1, (int)new Every(null).getPeriod().getValue());
+    }
+    
+    @Test
+    public void testAsString() throws Exception {
+        assertEquals("0/1", new Every(new On(new IntegerFieldValue(0)), new IntegerFieldValue(1)).asString());
     }
 }

--- a/src/test/java/com/cronutils/parser/CronParserTest.java
+++ b/src/test/java/com/cronutils/parser/CronParserTest.java
@@ -1,5 +1,6 @@
 package com.cronutils.parser;
 
+import com.cronutils.model.Cron;
 import com.cronutils.model.CronType;
 import com.cronutils.model.definition.CronDefinition;
 import com.cronutils.model.definition.CronDefinitionBuilder;
@@ -16,6 +17,7 @@ import org.mockito.MockitoAnnotations;
 
 import java.util.Set;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.mockito.Mockito.when;
 /*
@@ -135,5 +137,14 @@ public class CronParserTest {
         parser = new CronParser(quartzDefinition);
         
         parser.parse("0/60 0 0 1 1 ? 2017/3");
+    }
+    
+    @Test
+    public void testThatEveryMinuteIsPreserved() {
+        CronDefinition quartzDefinition = CronDefinitionBuilder.instanceDefinitionFor(CronType.QUARTZ);
+        parser = new CronParser(quartzDefinition);
+        
+        Cron expression = parser.parse("0 0/1 * 1/1 * ? *");
+        assertEquals("0 0/1 * 1/1 * ? *", expression.asString());
     }
 }


### PR DESCRIPTION
… fields with time periods.

@jmrozanec, I'm no expert on cron, but I wanted to demonstrate something that appears odd to me when writing a field value (with a period == 1) to a string.

If I were to pass in 0/1 for the minutes field, I'd expect 0/1 or * as a possible output.  Instead, I see 0, which to me seems wrong because it'd be 0 minute (out of 0-59).

I believe it comes down to [this line in the Every class](https://github.com/jmrozanec/cron-utils/blob/master/src/main/java/com/cronutils/model/field/expression/Every.java#L49).

This PR doesn't contain any business logic changes yet.  Can you please confirm if this is a bug or not?  Thank you for your time!