### PR TITLE
Fix for ExecutionTime#isMatch for lower bound date matching cron expression requirements (issue #192)

### DIFF
--- a/src/main/java/com/cronutils/model/time/ExecutionTime.java
+++ b/src/main/java/com/cronutils/model/time/ExecutionTime.java
@@ -488,22 +488,20 @@ public class ExecutionTime {
      */
     public boolean isMatch(ZonedDateTime date){
         Optional<ZonedDateTime> last = lastExecution(date);
-        if(last.isPresent()){
-            Optional<ZonedDateTime> next = nextExecution(last.get());
-            if(next.isPresent()){
-                return next.get().equals(date);
-            }else{
-                boolean everythingInRange = false;
-                try {
-                    everythingInRange = dateValuesInExpectedRanges(nextClosestMatch(date), date);
-                } catch (NoSuchValueException ignored) {}
-                try {
-                    everythingInRange = dateValuesInExpectedRanges(previousClosestMatch(date), date);
-                } catch (NoSuchValueException ignored) {}
-                return everythingInRange;
-            }
-        }
-        return false;
+        Optional<ZonedDateTime> next = nextExecution(last.isPresent() ? last.get() : date.minusSeconds(1));
+        
+        if(next.isPresent())
+            return next.get().equals(date);
+        
+        boolean everythingInRange = false;
+        try {
+            everythingInRange = dateValuesInExpectedRanges(nextClosestMatch(date), date);
+        } catch (NoSuchValueException ignored) {}
+        try {
+            everythingInRange = dateValuesInExpectedRanges(previousClosestMatch(date), date);
+        } catch (NoSuchValueException ignored) {}
+        
+        return everythingInRange;
     }
 
     private boolean dateValuesInExpectedRanges(ZonedDateTime validCronDate, ZonedDateTime date){

--- a/src/test/java/com/cronutils/model/time/ExecutionTimeQuartzIntegrationTest.java
+++ b/src/test/java/com/cronutils/model/time/ExecutionTimeQuartzIntegrationTest.java
@@ -646,6 +646,16 @@ public class ExecutionTimeQuartzIntegrationTest {
         ZonedDateTime expected = ZonedDateTime.of( 2017, 01, 31, 8, 0, 0, 0, ZoneId.systemDefault() );
         assertEquals( expected, next );
     }
+    
+    @Test //#192
+    public void mustMatchLowerBoundDateMatchingCronExpressionRequirements() {
+        CronParser parser = new CronParser( CronDefinitionBuilder.instanceDefinitionFor(QUARTZ));
+        ZonedDateTime start = ZonedDateTime.of( 2017, 01, 1, 0, 0, 0, 0, ZoneId.systemDefault() );
+        ExecutionTime executionTime = ExecutionTime.forCron( parser.parse( "0 0 0 1 * ?" ) ); // every 1st of Month 1970-2099
+        ExecutionTime constraintExecutionTime = ExecutionTime.forCron( parser.parse( "0 0 0 1 * ? 2017" ) ); // every 1st of Month for 2017
+        assertEquals("year constraint shouldn't have an impact on next execution", executionTime.nextExecution(start.minusSeconds(1)), constraintExecutionTime.nextExecution(start.minusSeconds(1)));
+        assertEquals("year constraint shouldn't have an impact on match result", executionTime.isMatch(start),  constraintExecutionTime.isMatch(start));
+    }
 
     private Duration getMinimumInterval(String quartzPattern) {
         ExecutionTime et = ExecutionTime.forCron(parser.parse(quartzPattern));


### PR DESCRIPTION
Proposal to fix #192.

Although all test cases are passed the fix should be revised, since I did not yet understand the necessity of ExecutionTime#dateValuesInExpectedRanges. However the naive approach to solely compute nextExecution(date.minusSeconds(1)) and if present compare with date didn't work (i.e. causes some tests to fail).