### PR TITLE
Fixed issue on #194, i.e. fixed test case. 

### DIFF
--- a/src/test/java/com/cronutils/model/field/FieldParserTest.java
+++ b/src/test/java/com/cronutils/model/field/FieldParserTest.java
@@ -16,54 +16,65 @@ import com.cronutils.model.field.value.IntegerFieldValue;
 import com.cronutils.model.field.value.SpecialChar;
 import com.cronutils.parser.FieldParser;
 
+
 /*
- * Copyright 2015 jmrozanec
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
+ * Copyright 2015 jmrozanec Licensed under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * http://www.apache.org/licenses/LICENSE-2.0
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law
+ * or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
  */
 public class FieldParserTest {
     private FieldParser parser;
+
 
     @Before
     public void setUp() {
         parser = new FieldParser(FieldConstraintsBuilder.instance().addHashSupport().createConstraintsInstance());
     }
 
+
     @Test
     public void testParseAlways() throws Exception {
         assertTrue(parser.parse("*") instanceof Always);
     }
 
+
     @Test
     public void testParseAlwaysEveryX() throws Exception {
         int every = 5;
         Every expression = (Every) parser.parse("*/" + every);
-        assertEquals(every, (int)(expression).getPeriod().getValue());
+        assertEquals(every, (int) (expression).getPeriod().getValue());
         assertTrue(expression.getExpression() instanceof Always);
     }
+
 
     @Test
     public void testParseOn() throws Exception {
         int on = 5;
-        assertEquals(on, (int)((On) parser.parse("" + on)).getTime().getValue());
+        assertEquals(on, (int) ((On) parser.parse("" + on)).getTime().getValue());
     }
 
+
     @Test //#194
-    public void testParseOnWithHash01() throws Exception {
+    public void testParseOnWithHash01() {
         int on = 5;
         int hashValue = 3;
         On onExpression = (On) parser.parse(String.format("%s#%s", on, hashValue));
-        assertEquals(on, (int)(onExpression.getTime().getValue()));
+        assertEquals(on, (int) (onExpression.getTime().getValue()));
         assertEquals(hashValue, onExpression.getNth().getValue().intValue());
         assertEquals(SpecialChar.HASH, onExpression.getSpecialChar().getValue());
     }
+
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testRejectHashIfFieldDoesNotClaimToSupportIt() {
+        new FieldParser(FieldConstraintsBuilder.instance().createConstraintsInstance()).parse("5#3");
+    }
+
 
     @Test
     public void testParseAnd() throws Exception {
@@ -71,18 +82,20 @@ public class FieldParserTest {
         int on2 = 4;
         And and = (And) parser.parse(String.format("%s,%s", on1, on2));
         assertEquals(2, and.getExpressions().size());
-        assertEquals(on1, (int)((On) and.getExpressions().get(0)).getTime().getValue());
-        assertEquals(on2, (int)((On) and.getExpressions().get(1)).getTime().getValue());
+        assertEquals(on1, (int) ((On) and.getExpressions().get(0)).getTime().getValue());
+        assertEquals(on2, (int) ((On) and.getExpressions().get(1)).getTime().getValue());
     }
+
 
     @Test
     public void testParseBetween() throws Exception {
         int from = 3;
         int to = 4;
         Between between = (Between) parser.parse(String.format("%s-%s", from, to));
-        assertEquals(from, (int)((IntegerFieldValue)between.getFrom()).getValue());
-        assertEquals(to, (int)((IntegerFieldValue)between.getTo()).getValue());
+        assertEquals(from, (int) ((IntegerFieldValue) between.getFrom()).getValue());
+        assertEquals(to, (int) ((IntegerFieldValue) between.getTo()).getValue());
     }
+
 
     @Test
     public void testParseBetweenEveryX() throws Exception {
@@ -91,10 +104,11 @@ public class FieldParserTest {
         int every = 5;
         Every expression = (Every) parser.parse(String.format("%s-%s/%s", from, to, every));
         Between between = (Between) expression.getExpression();
-        assertEquals(from, (int)((IntegerFieldValue)between.getFrom()).getValue());
-        assertEquals(to, (int)((IntegerFieldValue)between.getTo()).getValue());
-        assertEquals(every, (int)(expression.getPeriod()).getValue());
+        assertEquals(from, (int) ((IntegerFieldValue) between.getFrom()).getValue());
+        assertEquals(to, (int) ((IntegerFieldValue) between.getTo()).getValue());
+        assertEquals(every, (int) (expression.getPeriod()).getValue());
     }
+
 
     @Test(expected = NullPointerException.class)
     public void testCostructorNullConstraints() throws Exception {

--- a/src/test/java/com/cronutils/model/field/FieldParserTest.java
+++ b/src/test/java/com/cronutils/model/field/FieldParserTest.java
@@ -33,7 +33,7 @@ public class FieldParserTest {
 
     @Before
     public void setUp() {
-        parser = new FieldParser(FieldConstraintsBuilder.instance().createConstraintsInstance());
+        parser = new FieldParser(FieldConstraintsBuilder.instance().addHashSupport().createConstraintsInstance());
     }
 
     @Test
@@ -55,7 +55,7 @@ public class FieldParserTest {
         assertEquals(on, (int)((On) parser.parse("" + on)).getTime().getValue());
     }
 
-    //@Test//TODO #194
+    @Test //#194
     public void testParseOnWithHash01() throws Exception {
         int on = 5;
         int hashValue = 3;


### PR DESCRIPTION
To pass the test, the created field now effectively needs to declare hash support. Previously hash was
handled although support of it may not have been declared.

@jmrozanec sorry that this fix of the test case got lost on the provided pull request