### PR TITLE
Fix #203 - add option to match both day of week and day of month

### DIFF
--- a/src/main/java/com/cronutils/model/definition/CronDefinition.java
+++ b/src/main/java/com/cronutils/model/definition/CronDefinition.java
@@ -32,6 +32,7 @@ public class CronDefinition implements Serializable {
     private Map<CronFieldName, FieldDefinition> fieldDefinitions;
     private Set<CronConstraint> cronConstraints;
     private boolean strictRanges;
+    private boolean matchDayOfWeekAndDayOfMonth;
 
     /**
      * Constructor
@@ -39,7 +40,7 @@ public class CronDefinition implements Serializable {
      *                         Throws a NullPointerException if a null values is received
      *                         Throws an IllegalArgumentException if an empty list is received
      */
-    public CronDefinition(List<FieldDefinition> fieldDefinitions, Set<CronConstraint> cronConstraints, boolean strictRanges){
+    public CronDefinition(List<FieldDefinition> fieldDefinitions, Set<CronConstraint> cronConstraints, boolean strictRanges, boolean matchDayOfWeekAndDayOfMonth){
         Preconditions.checkNotNull(fieldDefinitions, "Field definitions must not be null");
         Preconditions.checkNotNull(cronConstraints, "Cron validations must not be null");
         Preconditions.checkNotNullNorEmpty(fieldDefinitions, "Field definitions must not be empty");
@@ -50,6 +51,7 @@ public class CronDefinition implements Serializable {
         }
         this.cronConstraints = Collections.unmodifiableSet(cronConstraints);
         this.strictRanges = strictRanges;
+        this.matchDayOfWeekAndDayOfMonth = matchDayOfWeekAndDayOfMonth;
     }
 
     /**
@@ -58,6 +60,14 @@ public class CronDefinition implements Serializable {
      */
     public boolean isStrictRanges() {
         return strictRanges;
+    }
+
+    /**
+     * If both the day of the week and day of the month should be matched
+     * @return true if both should be matched, false otherwise
+     */
+    public boolean isMatchDayOfWeekAndDayOfMonth() {
+        return matchDayOfWeekAndDayOfMonth;
     }
 
     /**

--- a/src/main/java/com/cronutils/model/definition/CronDefinitionBuilder.java
+++ b/src/main/java/com/cronutils/model/definition/CronDefinitionBuilder.java
@@ -34,6 +34,7 @@ public class CronDefinitionBuilder {
     private final Map<CronFieldName, FieldDefinition> fields = new HashMap<>();
     private final Set<CronConstraint> cronConstraints = new HashSet<>();
     private boolean enforceStrictRanges;
+    private boolean matchDayOfWeekAndDayOfMonth;
 
     /**
      * Constructor.
@@ -122,6 +123,15 @@ public class CronDefinitionBuilder {
     }
 
     /**
+     * Sets matchDayOfWeekAndDayOfMonth value to true
+     * @return this CronDefinitionBuilder instance
+     */
+    public CronDefinitionBuilder matchDayOfWeekAndDayOfMonth(){
+        matchDayOfWeekAndDayOfMonth = true;
+        return this;
+    }
+
+    /**
      * Adds a cron validation
      * @return this CronDefinitionBuilder instance
      */
@@ -148,7 +158,7 @@ public class CronDefinitionBuilder {
     public CronDefinition instance() {
         Set<CronConstraint> validations = new HashSet<CronConstraint>();
         validations.addAll(cronConstraints);
-        return new CronDefinition(fields.values().stream().sorted((o1,o2) -> o1.getFieldName().getOrder() - o2.getFieldName().getOrder()).collect(Collectors.toList()), validations, enforceStrictRanges);
+        return new CronDefinition(fields.values().stream().sorted((o1,o2) -> o1.getFieldName().getOrder() - o2.getFieldName().getOrder()).collect(Collectors.toList()), validations, enforceStrictRanges, matchDayOfWeekAndDayOfMonth);
     }
 
     /**
@@ -163,6 +173,7 @@ public class CronDefinitionBuilder {
                 .withMonth().and()
                 .withDayOfWeek().withValidRange(0,6).withMondayDoWValue(1).and()
                 .enforceStrictRanges()
+                .matchDayOfWeekAndDayOfMonth()
                 .instance();
     }
 

--- a/src/main/java/com/cronutils/model/time/ExecutionTime.java
+++ b/src/main/java/com/cronutils/model/time/ExecutionTime.java
@@ -19,6 +19,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import com.google.common.collect.Sets;
 import org.threeten.bp.Duration;
 import org.threeten.bp.LocalDate;
 import org.threeten.bp.LocalDateTime;
@@ -550,10 +551,19 @@ public class ExecutionTime {
             candidates.addAll(createDayOfMonthValueGeneratorInstance(daysOfMonthCronField,
                     year, month).generateCandidates(1, lengthOfMonth));
         } else {
-            candidates.addAll(createDayOfWeekValueGeneratorInstance(daysOfWeekCronField, 
-                    year, month, mondayDoWValue).generateCandidates(1, lengthOfMonth));
-            candidates.addAll(createDayOfMonthValueGeneratorInstance(daysOfMonthCronField, year, month)
-                    .generateCandidates(1, lengthOfMonth));
+            List<Integer> dayOfWeekCandidates = createDayOfWeekValueGeneratorInstance(daysOfWeekCronField,
+                year, month, mondayDoWValue).generateCandidates(1, lengthOfMonth);
+            List<Integer> dayOfMonthCandidates = createDayOfMonthValueGeneratorInstance(daysOfMonthCronField, year, month)
+                .generateCandidates(1, lengthOfMonth);
+            if (cronDefinition.isMatchDayOfWeekAndDayOfMonth()){
+                Set<Integer> dayOfWeekCandidatesSet = Sets.newHashSet(dayOfWeekCandidates);
+                Set<Integer> dayOfMonthCandidatesSet = Sets.newHashSet(dayOfMonthCandidates);
+                candidates.addAll(Sets.intersection(dayOfMonthCandidatesSet, dayOfWeekCandidatesSet));
+            }
+            else {
+                candidates.addAll(dayOfWeekCandidates);
+                candidates.addAll(dayOfMonthCandidates);
+            }
         }
         List<Integer> candidatesList = new ArrayList<>(candidates);
 		Collections.sort(candidatesList);

--- a/src/test/java/com/cronutils/model/definition/CronDefinitionTest.java
+++ b/src/test/java/com/cronutils/model/definition/CronDefinitionTest.java
@@ -32,6 +32,7 @@ import com.google.common.collect.Sets;
  */
 public class CronDefinitionTest {
     private boolean enforceStrictRange;
+    private boolean matchDayOfWeekAndDayOfMonth;
     private CronFieldName testFieldName1;
     private CronFieldName testFieldName2;
     private CronFieldName testFieldName3;
@@ -54,22 +55,23 @@ public class CronDefinitionTest {
         when(mockFieldDefinition3optional.isOptional()).thenReturn(Boolean.TRUE);
 
         enforceStrictRange = false;
+        matchDayOfWeekAndDayOfMonth = false;
     }
 
 
     @Test(expected = NullPointerException.class)
     public void testConstructorNullFieldsParameter() throws Exception {
-        new CronDefinition(null, Sets.newHashSet(), enforceStrictRange);
+        new CronDefinition(null, Sets.newHashSet(), enforceStrictRange, matchDayOfWeekAndDayOfMonth);
     }
 
     @Test(expected = NullPointerException.class)
     public void testConstructorNullConstraintsParameter() throws Exception {
-        new CronDefinition(Lists.newArrayList(), null, enforceStrictRange);
+        new CronDefinition(Lists.newArrayList(), null, enforceStrictRange, matchDayOfWeekAndDayOfMonth);
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void testConstructorEmptyFieldsParameter() throws Exception {
-        new CronDefinition(new ArrayList<>(), Sets.newHashSet(), enforceStrictRange);
+        new CronDefinition(new ArrayList<>(), Sets.newHashSet(), enforceStrictRange, matchDayOfWeekAndDayOfMonth);
     }
 
     @Test
@@ -78,21 +80,21 @@ public class CronDefinitionTest {
         fields.add(mockFieldDefinition1);
         fields.add(mockFieldDefinition2);
         fields.add(mockFieldDefinition3optional);
-        assertTrue(new CronDefinition(fields, Sets.newHashSet(), enforceStrictRange).getFieldDefinitions().stream().sorted((o1,o2) -> o1.getFieldName().getOrder() - o2.getFieldName().getOrder()).collect(Collectors.toList()).get(fields.size()-1).isOptional());
+        assertTrue(new CronDefinition(fields, Sets.newHashSet(), enforceStrictRange, matchDayOfWeekAndDayOfMonth).getFieldDefinitions().stream().sorted((o1,o2) -> o1.getFieldName().getOrder() - o2.getFieldName().getOrder()).collect(Collectors.toList()).get(fields.size()-1).isOptional());
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void testLastFieldOptionalNotAllowedOnSingleFieldDefinition() throws Exception {
         List<FieldDefinition> fields = Lists.newArrayList();
         fields.add(mockFieldDefinition3optional);
-        new CronDefinition(fields, Sets.newHashSet(), enforceStrictRange);
+        new CronDefinition(fields, Sets.newHashSet(), enforceStrictRange, matchDayOfWeekAndDayOfMonth);
     }
 
     @Test
     public void testGetFieldDefinitions() throws Exception {
         List<FieldDefinition> fields = Lists.newArrayList();
         fields.add(mockFieldDefinition1);
-        CronDefinition cronDefinition = new CronDefinition(fields, Sets.newHashSet(), enforceStrictRange);
+        CronDefinition cronDefinition = new CronDefinition(fields, Sets.newHashSet(), enforceStrictRange, matchDayOfWeekAndDayOfMonth);
         assertNotNull(cronDefinition.getFieldDefinitions());
         assertEquals(1, cronDefinition.getFieldDefinitions().size());
         assertTrue(cronDefinition.getFieldDefinitions().contains(mockFieldDefinition1));

--- a/src/test/java/com/cronutils/model/time/ExecutionTimeCron4jIntegrationTest.java
+++ b/src/test/java/com/cronutils/model/time/ExecutionTimeCron4jIntegrationTest.java
@@ -193,12 +193,13 @@ public class ExecutionTimeCron4jIntegrationTest {
         for (int expectedYear : expectedYears) {
             assert (executionTime.nextExecution(next).isPresent());
             next = executionTime.nextExecution(next).get();
-            log.debug("Expecting Tuesday January 1, {}", expectedYear);
-            String expectedDate = "Tuesday, January 1, " + expectedYear;
-            assertEquals("Expected " + expectedDate, DayOfWeek.TUESDAY, next.getDayOfWeek());
-            assertEquals(1, next.getDayOfMonth());
-            assertEquals(expectedYear, next.getYear());
-            assertEquals(9, next.getHour());
+            ZonedDateTime expectedDate = ZonedDateTime.of(expectedYear, 1, 1, 9, 0, 0 , 0, ZoneId.systemDefault());
+            String expectedMessage = String.format("Expected next execution time: %s, Actual next execution time: %s", expectedDate, next);
+            assertEquals(expectedMessage, DayOfWeek.TUESDAY, next.getDayOfWeek());
+            assertEquals(expectedMessage, 1, next.getDayOfMonth());
+            assertEquals(expectedMessage, expectedYear, next.getYear());
+            assertEquals(expectedMessage, 9, next.getHour());
+            assertEquals(expectedMessage, expectedDate, next);
         }
     }
 
@@ -229,8 +230,9 @@ public class ExecutionTimeCron4jIntegrationTest {
             assert(nextExecution.isPresent());
             next = nextExecution.get();
             log.debug("Execution #{} date: {}", i, next);
-            assertEquals(dayOfWeek, next.getDayOfWeek());
-            assertEquals(dayOfMonth, next.getDayOfMonth());
+            assertEquals("Incorrect day of the week", dayOfWeek, next.getDayOfWeek());
+            assertEquals("Incorrect day of the month", dayOfMonth, next.getDayOfMonth());
+            assertEquals("Incorrect month", month, next.getMonthValue());
         }
     }
 }

--- a/src/test/java/com/cronutils/model/time/ExecutionTimeCron4jIntegrationTest.java
+++ b/src/test/java/com/cronutils/model/time/ExecutionTimeCron4jIntegrationTest.java
@@ -182,18 +182,14 @@ public class ExecutionTimeCron4jIntegrationTest {
     @Test
     public void testFixedDayOfMonthAndDayOfWeek() throws Exception {
         // Run only on January 1st if it is a Tuesday, at 9:00AM
-        // The next four Tuesday January 1 after January 1, 2017 are:
-        // Tue Jan 01 09:00:00 EST 2019
-        // Tue Jan 01 09:00:00 EST 2030
-        // Tue Jan 01 09:00:00 EST 2036
-        // Tue Jan 01 09:00:00 EST 2041
-        int[] expectedYears = {2019, 2030, 2036, 2041};
         ExecutionTime executionTime = ExecutionTime.forCron(cron4jCronParser.parse("0 9 1 1 tue"));
+        // The next four Tuesday January 1 after January 1, 2017 are in 2019, 2030, 2036, and 2041
+        int[] expectedYears = {2019, 2030, 2036, 2041};
         ZonedDateTime next = ZonedDateTime.of(2017, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
         for (int expectedYear : expectedYears) {
             assert (executionTime.nextExecution(next).isPresent());
             next = executionTime.nextExecution(next).get();
-            ZonedDateTime expectedDate = ZonedDateTime.of(expectedYear, 1, 1, 9, 0, 0 , 0, ZoneId.systemDefault());
+            ZonedDateTime expectedDate = ZonedDateTime.of(expectedYear, 1, 1, 9, 0, 0, 0, ZoneId.systemDefault());
             String expectedMessage = String.format("Expected next execution time: %s, Actual next execution time: %s", expectedDate, next);
             assertEquals(expectedMessage, DayOfWeek.TUESDAY, next.getDayOfWeek());
             assertEquals(expectedMessage, 1, next.getDayOfMonth());
@@ -220,7 +216,7 @@ public class ExecutionTimeCron4jIntegrationTest {
         int month = random.nextInt(12) + 1;
         // using max length so it is possible to use February 29 (leap-year)
         int dayOfMonth = random.nextInt(Month.of(month).maxLength()) + 1;
-        String expression = "0 0 " + dayOfMonth + " " + month + " " + dayOfWeekValue;
+        String expression = String.format("0 0 %d %d %d", dayOfMonth, month, dayOfWeekValue);
         ExecutionTime executionTime = ExecutionTime.forCron(cron4jCronParser.parse(expression));
         log.debug("cron4j expression: {}", expression);
         ZonedDateTime next = ZonedDateTime.now();


### PR DESCRIPTION
Adds a matchDayOfWeekAndDayOfMonth option to the CronDefinitionBuilder. Defaults to false.
The cron4j definition sets it to true to match the cron4j specification.

ExecutionTime only generates dates that match both the day of week and day of month if matchDayOfWeekAndDayOfMonth of the CronDefinition is set to true.