### PR TITLE
Fix #215 by accounting for the shift in day of week by the cron definition

### DIFF
--- a/src/main/java/com/cronutils/model/time/generator/BetweenDayOfWeekValueGenerator.java
+++ b/src/main/java/com/cronutils/model/time/generator/BetweenDayOfWeekValueGenerator.java
@@ -125,6 +125,19 @@ class BetweenDayOfWeekValueGenerator extends FieldValueGenerator {
 
 	@Override
 	public boolean isMatch(int value) {
-        return dowValidValues.contains(LocalDate.of(year, month, value).getDayOfWeek().getValue());
+        // DayOfWeek getValue returns 1 (Monday) - 7 (Sunday),
+        // so we should factor in the monday DoW used to generate
+        // the valid DoW values
+        int localDateDoW = LocalDate.of(year, month, value).getDayOfWeek().getValue();
+
+        // Sunday's value is mondayDoWValue-1 when generating the valid values
+        // Ex.
+        // cron4j 0(Sun)-6(Sat), mondayDoW = 1
+        // quartz 1(Sun)-7(Sat), mondayDoW = 2
+
+        // modulo 7 to convert Sunday from 7 to 0 and adjust to match the mondayDoWValue
+        int cronDoW = localDateDoW % 7 + (mondayDoWValue.getMondayDoWValue() - 1);
+
+        return dowValidValues.contains(cronDoW);
 	}
 }

--- a/src/test/java/com/cronutils/Issue215Test.java
+++ b/src/test/java/com/cronutils/Issue215Test.java
@@ -5,10 +5,6 @@ package com.cronutils;
 
 import static org.junit.Assert.*;
 
-import java.time.LocalDateTime;
-import java.time.ZoneId;
-import java.time.ZonedDateTime;
-
 import org.junit.Test;
 
 import com.cronutils.model.Cron;
@@ -17,33 +13,105 @@ import com.cronutils.model.definition.CronDefinitionBuilder;
 import com.cronutils.model.time.ExecutionTime;
 import com.cronutils.parser.CronParser;
 import com.google.common.base.Optional;
+import org.threeten.bp.LocalDateTime;
+import org.threeten.bp.Month;
+import org.threeten.bp.ZoneId;
+import org.threeten.bp.ZonedDateTime;
 
 public class Issue215Test {
 
-    // test für https://github.com/jmrozanec/cron-utils/issues/215
-    //@Test TODO issue 215
+    // test for https://github.com/jmrozanec/cron-utils/issues/215
+    @Test
     public void testWorkdayBugWithNextMonth() {
 
-        testWorkdays8( LocalDateTime.of( 2017, 7, 7, 10, 00 ), LocalDateTime.of( 2017, 7, 10, 8, 00 ) ); //good
-        testWorkdays8( LocalDateTime.of( 2017, 8, 31, 10, 00 ), LocalDateTime.of( 2017, 9, 1, 8, 00 ) ); //good
-        testWorkdays8( LocalDateTime.of( 2017, 6, 30, 10, 00 ), LocalDateTime.of( 2017, 7, 3, 8, 00 ) ); //not good
-        testWorkdays8( LocalDateTime.of( 2017, 9, 29, 10, 00 ), LocalDateTime.of( 2017, 10, 2, 8, 00 ) ); //not good
+        testWorkdays8Quartz( LocalDateTime.of( 2017, 7, 7, 10, 0 ), LocalDateTime.of( 2017, 7, 10, 8, 0 ) );
+        testWorkdays8Quartz( LocalDateTime.of( 2017, 8, 31, 10, 0 ), LocalDateTime.of( 2017, 9, 1, 8, 0 ) );
+        testWorkdays8Quartz( LocalDateTime.of( 2017, 6, 30, 10, 0 ), LocalDateTime.of( 2017, 7, 3, 8, 0 ) );
+        testWorkdays8Quartz( LocalDateTime.of( 2017, 9, 29, 10, 0 ), LocalDateTime.of( 2017, 10, 2, 8, 0 ) );
+
+        testWorkdays8Cron4j( LocalDateTime.of( 2017, 7, 7, 10, 0 ), LocalDateTime.of( 2017, 7, 10, 8, 0 ) ); //good
+        testWorkdays8Cron4j( LocalDateTime.of( 2017, 8, 31, 10, 0 ), LocalDateTime.of( 2017, 9, 1, 8, 0 ) ); //good
+        testWorkdays8Cron4j( LocalDateTime.of( 2017, 6, 30, 10, 0 ), LocalDateTime.of( 2017, 7, 3, 8, 0 ) ); //not good
+        testWorkdays8Cron4j( LocalDateTime.of( 2017, 9, 29, 10, 0 ), LocalDateTime.of( 2017, 10, 2, 8, 0 ) ); //not good
     }
 
-    private void testWorkdays8( LocalDateTime startDate, LocalDateTime expectedNextExecution ) {
+    @Test
+    public void testFridayToSaturday(){
+        // cron4j and quartz have different monday day of week values, so test both
+        testFridayToSaturdayQuartz(
+                LocalDateTime.of(2017, Month.MARCH, 28, 0, 0),
+                LocalDateTime.of(2017, Month.MARCH, 31, 8, 0));
+        testFridayToSaturdayQuartz(
+                LocalDateTime.of(2017, Month.MARCH, 31, 9, 0),
+                LocalDateTime.of(2017, Month.APRIL, 1, 8, 0));
+
+        testFridayToSaturdayCron4j(
+                LocalDateTime.of(2017, Month.MARCH, 28, 0, 0),
+                LocalDateTime.of(2017, Month.MARCH, 31, 8, 0));
+        testFridayToSaturdayCron4j(
+                LocalDateTime.of(2017, Month.MARCH, 31, 9, 0),
+                LocalDateTime.of(2017, Month.APRIL, 1, 8, 0));
+
+        testFridayToSaturdayQuartz(
+                LocalDateTime.of(2017, Month.JULY, 10, 0, 0),
+                LocalDateTime.of(2017, Month.JULY, 14, 8, 0));
+        testFridayToSaturdayQuartz(
+                LocalDateTime.of(2017, Month.JULY, 15, 0, 0),
+                LocalDateTime.of(2017, Month.JULY, 15, 8, 0));
+
+        testFridayToSaturdayCron4j(
+                LocalDateTime.of(2017, Month.JULY, 10, 0, 0),
+                LocalDateTime.of(2017, Month.JULY, 14, 8, 0));
+        testFridayToSaturdayCron4j(
+                LocalDateTime.of(2017, Month.JULY, 15, 0, 0),
+                LocalDateTime.of(2017, Month.JULY, 15, 8, 0));
+
+        testFridayToSaturdayQuartz(
+                LocalDateTime.of(2010, Month.DECEMBER, 31, 0, 0),
+                LocalDateTime.of(2010, Month.DECEMBER, 31, 8, 0));
+
+        testFridayToSaturdayQuartz(
+                LocalDateTime.of(2010, Month.DECEMBER, 31, 9, 0),
+                LocalDateTime.of(2011, Month.JANUARY, 1, 8, 0));
+
+        testFridayToSaturdayCron4j(
+                LocalDateTime.of(2010, Month.DECEMBER, 31, 0, 0),
+                LocalDateTime.of(2010, Month.DECEMBER, 31, 8, 0));
+
+        testFridayToSaturdayCron4j(
+                LocalDateTime.of(2010, Month.DECEMBER, 31, 9, 0),
+                LocalDateTime.of(2011, Month.JANUARY, 1, 8, 0));
+    }
+
+    private void testFridayToSaturdayQuartz(LocalDateTime startDate, LocalDateTime expectedNextExecution){
+        CronParser parser = new CronParser(CronDefinitionBuilder.instanceDefinitionFor(CronType.QUARTZ));
+        Cron quartzCron = parser.parse("0 0 8 ? * FRI-SAT");
+        checkNextExecution(startDate, expectedNextExecution, quartzCron);
+    }
+
+    private void testFridayToSaturdayCron4j(LocalDateTime startDate, LocalDateTime expectedNextExecution){
+        CronParser parser = new CronParser(CronDefinitionBuilder.instanceDefinitionFor(CronType.CRON4J));
+        Cron quartzCron = parser.parse("0 8 * * FRI-SAT");
+        checkNextExecution(startDate, expectedNextExecution, quartzCron);
+    }
+
+    private void testWorkdays8Quartz(LocalDateTime startDate, LocalDateTime expectedNextExecution ) {
         CronParser parser = new CronParser( CronDefinitionBuilder.instanceDefinitionFor( CronType.QUARTZ ) );
         Cron quartzCron = parser.parse( "0 0 8 ? * MON-FRI" );
-        ExecutionTime executionTime = ExecutionTime.forCron( quartzCron );
+        checkNextExecution(startDate, expectedNextExecution, quartzCron);
+    }
+
+    private void testWorkdays8Cron4j(LocalDateTime startDate, LocalDateTime expectedNextExecution ) {
+        CronParser parser = new CronParser( CronDefinitionBuilder.instanceDefinitionFor( CronType.CRON4J ) );
+        Cron quartzCron = parser.parse( "0 8 * * MON-FRI" );
+        checkNextExecution(startDate, expectedNextExecution, quartzCron);
+    }
+
+    private void checkNextExecution(LocalDateTime startDate, LocalDateTime expectedNextExecution, Cron cron) {
+        ExecutionTime executionTime = ExecutionTime.forCron( cron );
         ZonedDateTime zonedDateTime = ZonedDateTime.of( startDate, ZoneId.systemDefault() );
-        org.threeten.bp.ZonedDateTime xx = timeToThreeten( zonedDateTime );
-        Optional<org.threeten.bp.ZonedDateTime> next = executionTime.nextExecution( xx );
-        assertEquals( timeToThreeten( ZonedDateTime.of( expectedNextExecution, ZoneId.systemDefault() ) ), next.get() );
+        Optional<ZonedDateTime> next = executionTime.nextExecution( zonedDateTime );
+        assert(next.isPresent());
+        assertEquals(ZonedDateTime.of( expectedNextExecution, ZoneId.systemDefault() ) , next.get() );
     }
-
-    private org.threeten.bp.ZonedDateTime timeToThreeten( ZonedDateTime zonedDateTime ) {
-        org.threeten.bp.ZonedDateTime xx =
-                        org.threeten.bp.ZonedDateTime.of( zonedDateTime.getYear(), zonedDateTime.getMonthValue(), zonedDateTime.getDayOfMonth(), zonedDateTime.getHour(), zonedDateTime.getMinute(), zonedDateTime.getSecond(), zonedDateTime.getNano(), org.threeten.bp.ZoneId.of( zonedDateTime.getZone().getId() ) );
-        return xx;
-    }
-
 }


### PR DESCRIPTION
- handle the monday day of week used to generate the valid day of week (numeric) values
- replace usage of Java 8 time classes in the test with the backport