### PR TITLE
Replace usage of Java 8 stream classes with Java 7 compliant code.

### DIFF
--- a/src/main/java/com/cronutils/model/definition/CronDefinitionBuilder.java
+++ b/src/main/java/com/cronutils/model/definition/CronDefinitionBuilder.java
@@ -12,10 +12,7 @@
  */
 package com.cronutils.model.definition;
 
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 
 import com.cronutils.model.CronType;
 import com.cronutils.model.field.CronFieldName;
@@ -24,8 +21,6 @@ import com.cronutils.model.field.definition.FieldDefinition;
 import com.cronutils.model.field.definition.FieldDefinitionBuilder;
 import com.cronutils.model.field.definition.FieldQuestionMarkDefinitionBuilder;
 import com.cronutils.model.field.definition.FieldSpecialCharsDefinitionBuilder;
-
-import java.util.stream.Collectors;
 
 /**
  * Builder that allows to define and create CronDefinition instances
@@ -158,7 +153,9 @@ public class CronDefinitionBuilder {
     public CronDefinition instance() {
         Set<CronConstraint> validations = new HashSet<CronConstraint>();
         validations.addAll(cronConstraints);
-        return new CronDefinition(fields.values().stream().sorted((o1,o2) -> o1.getFieldName().getOrder() - o2.getFieldName().getOrder()).collect(Collectors.toList()), validations, enforceStrictRanges, matchDayOfWeekAndDayOfMonth);
+        List<FieldDefinition> values = new ArrayList<>(fields.values());
+        values.sort(FieldDefinition.createFieldDefinitionComparator());
+        return new CronDefinition(values, validations, enforceStrictRanges, matchDayOfWeekAndDayOfMonth);
     }
 
     /**

--- a/src/main/java/com/cronutils/model/time/ExecutionTime.java
+++ b/src/main/java/com/cronutils/model/time/ExecutionTime.java
@@ -42,9 +42,6 @@ import com.cronutils.utils.VisibleForTesting;
 import com.google.common.base.Optional;
 import com.google.common.collect.Range;
 
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
-
 import static com.cronutils.model.field.CronFieldName.*;
 import static com.cronutils.model.time.generator.FieldValueGeneratorFactory.createDayOfYearValueGeneratorInstance;
 
@@ -410,11 +407,17 @@ public class ExecutionTime {
         List<Integer> candidates = createDayOfYearValueGeneratorInstance(daysOfYearCronField, year).generateCandidates(1, lengthOfYear);
         
         Range<Integer> rangeOfMonth = Range.closedOpen(LocalDate.of(year, month, 1).getDayOfYear(), month == 12 ? LocalDate.of(year, 12, 31).getDayOfYear() + 1 : LocalDate.of(year, month + 1, 1).getDayOfYear());
-        Stream<Integer> candidatesFilteredByMonth = candidates.stream().filter(dayOfYear -> rangeOfMonth.contains(dayOfYear));
-        Stream<Integer> uniqueCandidates = candidatesFilteredByMonth.distinct();
-        Stream<Integer> candidatesMappedToDayOfMonth = uniqueCandidates.map(dayOfYear -> LocalDate.ofYearDay(reference.getYear(), dayOfYear).getDayOfMonth());
-        
-        List<Integer> collectedCandidates = candidatesMappedToDayOfMonth.collect(Collectors.toList());
+        Set<Integer> uniqueCanidatesFilteredByMonth = new HashSet<>();
+        for(Integer dayOfYear: candidates){
+            if (rangeOfMonth.contains(dayOfYear)){
+                uniqueCanidatesFilteredByMonth.add(dayOfYear);
+            }
+        }
+        List<Integer> collectedCandidates = new ArrayList<>(uniqueCanidatesFilteredByMonth.size());
+        for(Integer dayOfYear: uniqueCanidatesFilteredByMonth){
+            collectedCandidates.add(LocalDate.ofYearDay(reference.getYear(), dayOfYear).getDayOfMonth());
+        }
+
         if(collectedCandidates.isEmpty())
             throw new NoDaysForMonthException();    //TODO try to avoid programming by exception, maybe we should better return Optional<TimeNode> and test on presence
         

--- a/src/main/java/com/cronutils/parser/CronParser.java
+++ b/src/main/java/com/cronutils/parser/CronParser.java
@@ -1,17 +1,14 @@
 package com.cronutils.parser;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.stream.Collectors;
-
 import com.cronutils.model.Cron;
 import com.cronutils.model.definition.CronDefinition;
 import com.cronutils.model.field.CronField;
+import com.cronutils.model.field.definition.FieldDefinition;
 import com.cronutils.utils.Preconditions;
 import com.cronutils.utils.StringUtils;
 import com.google.common.collect.ImmutableList;
+
+import java.util.*;
 
 /*
  * Copyright 2014 jmrozanec
@@ -51,18 +48,23 @@ public class CronParser {
 	 *            - cron definition instance
 	 */
 	private void buildPossibleExpressions(CronDefinition cronDefinition) {
-	    List<CronParserField> sortedExpression = cronDefinition.getFieldDefinitions().stream().map(fieldDefinition -> new CronParserField(fieldDefinition.getFieldName(), fieldDefinition.getConstraints(), fieldDefinition.isOptional())).sorted(CronParserField.createFieldTypeComparator()).collect(Collectors.toList());
-	    ImmutableList.Builder<CronParserField> expressionBuilder = ImmutableList.builder();
-	    for (CronParserField field : sortedExpression) {
-	        if (field.isOptional()) {
-	            List<CronParserField> possibleExpression = expressionBuilder.build();
-	            expressions.put(possibleExpression.size(), possibleExpression);
-	        }
-	            
-	        expressionBuilder.add(field);
-	    }
-	    List<CronParserField> longestPossibleExpression = expressionBuilder.build();
-	    expressions.put(longestPossibleExpression.size(), longestPossibleExpression);
+		List<CronParserField> sortedExpression = new ArrayList<>();
+		Set<FieldDefinition> fieldDefinitions = cronDefinition.getFieldDefinitions();
+		for(FieldDefinition fieldDefinition: fieldDefinitions){
+			sortedExpression.add(new CronParserField(fieldDefinition.getFieldName(), fieldDefinition.getConstraints(), fieldDefinition.isOptional()));
+		}
+		sortedExpression.sort(CronParserField.createFieldTypeComparator());
+		ImmutableList.Builder<CronParserField> expressionBuilder = ImmutableList.builder();
+		for (CronParserField field : sortedExpression) {
+			if (field.isOptional()) {
+				List<CronParserField> possibleExpression = expressionBuilder.build();
+				expressions.put(possibleExpression.size(), possibleExpression);
+			}
+
+			expressionBuilder.add(field);
+		}
+		List<CronParserField> longestPossibleExpression = expressionBuilder.build();
+		expressions.put(longestPossibleExpression.size(), longestPossibleExpression);
 	}
 
 	/**

--- a/src/test/java/com/cronutils/model/definition/CronDefinitionTest.java
+++ b/src/test/java/com/cronutils/model/definition/CronDefinitionTest.java
@@ -5,9 +5,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.when;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.stream.Collectors;
+import java.util.*;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -80,7 +78,11 @@ public class CronDefinitionTest {
         fields.add(mockFieldDefinition1);
         fields.add(mockFieldDefinition2);
         fields.add(mockFieldDefinition3optional);
-        assertTrue(new CronDefinition(fields, Sets.newHashSet(), enforceStrictRange, matchDayOfWeekAndDayOfMonth).getFieldDefinitions().stream().sorted((o1,o2) -> o1.getFieldName().getOrder() - o2.getFieldName().getOrder()).collect(Collectors.toList()).get(fields.size()-1).isOptional());
+        Set<FieldDefinition> fieldDefinitions = new CronDefinition(fields, Sets.newHashSet(), enforceStrictRange, matchDayOfWeekAndDayOfMonth)
+            .getFieldDefinitions();
+        List<FieldDefinition> sortedFieldDefinitions = new ArrayList<>(fieldDefinitions);
+        sortedFieldDefinitions.sort(FieldDefinition.createFieldDefinitionComparator());
+        assertTrue(sortedFieldDefinitions.get(fields.size()-1).isOptional());
     }
 
     @Test(expected = IllegalArgumentException.class)


### PR DESCRIPTION
Should resolve #221 by allowing the user to use cron-utils 6.0.3 with Java 7, which does not have a joda-time dependency.