### PR TITLE
#228 - Replace UNIX cron definition in test with modified definition

### DIFF
--- a/src/test/java/com/cronutils/Issue228Test.java
+++ b/src/test/java/com/cronutils/Issue228Test.java
@@ -1,7 +1,6 @@
 package com.cronutils;
 
 import com.cronutils.model.Cron;
-import com.cronutils.model.CronType;
 import com.cronutils.model.definition.CronDefinition;
 import com.cronutils.model.definition.CronDefinitionBuilder;
 import com.cronutils.model.time.ExecutionTime;
@@ -12,12 +11,22 @@ import org.threeten.bp.ZonedDateTime;
 import static org.junit.Assert.assertEquals;
 
 public class Issue228Test {
+
     /**
-     * Issue #228: dayOfWeek just isn't honored in the cron next execution evaluation and needs to be
+     * This is the UNIX cron definition with a single modification to match both Day Of Week and Day Of Month
      */
-    //@Test
+    private CronDefinition cronDefinition = CronDefinitionBuilder.defineCron()
+        .withMinutes().and()
+        .withHours().and()
+        .withDayOfMonth().and()
+        .withMonth().and()
+        .withDayOfWeek().withValidRange(0, 7).withMondayDoWValue(1).withIntMapping(7, 0).and()
+        .enforceStrictRanges()
+        .matchDayOfWeekAndDayOfMonth() // the regular UNIX cron definition permits matching either DoW or DoM
+        .instance();
+
+    @Test
     public void testFirstMondayOfTheMonthNextExecution() {
-        CronDefinition cronDefinition = CronDefinitionBuilder.instanceDefinitionFor(CronType.UNIX);
         CronParser parser = new CronParser(cronDefinition);
 
         // This is 9am on a day between the 1st and 7th which is a Monday (in this case it should be Oct 2
@@ -26,9 +35,8 @@ public class Issue228Test {
         assertEquals(ZonedDateTime.parse("2017-10-02T09:00-07:00"), ExecutionTime.forCron(myCron).nextExecution(time).get());
     }
 
-    //@Test
+    @Test
     public void testEveryWeekdayFirstWeekOfMonthNextExecution() {
-        CronDefinition cronDefinition = CronDefinitionBuilder.instanceDefinitionFor(CronType.UNIX);
         CronParser parser = new CronParser(cronDefinition);
 
         // This is 9am on Mon-Fri day between the 1st and 7th (in this case it should be Oct 2)
@@ -37,9 +45,8 @@ public class Issue228Test {
         assertEquals(ZonedDateTime.parse("2017-10-02T09:00-07:00"), ExecutionTime.forCron(myCron).nextExecution(time).get());
     }
 
-    //@Test
+    @Test
     public void testEveryWeekendFirstWeekOfMonthNextExecution() {
-        CronDefinition cronDefinition = CronDefinitionBuilder.instanceDefinitionFor(CronType.UNIX);
         CronParser parser = new CronParser(cronDefinition);
 
         // This is 9am on Sat and Sun day between the 1st and 7th (in this case it should be Oct 1)
@@ -48,9 +55,8 @@ public class Issue228Test {
         assertEquals(ZonedDateTime.parse("2017-10-01T09:00-07:00"), ExecutionTime.forCron(myCron).nextExecution(time).get());
     }
 
-    //@Test
+    @Test
     public void testEveryWeekdaySecondWeekOfMonthNextExecution() {
-        CronDefinition cronDefinition = CronDefinitionBuilder.instanceDefinitionFor(CronType.UNIX);
         CronParser parser = new CronParser(cronDefinition);
 
         // This is 9am on Mon-Fri day between the 8th and 14th (in this case it should be Oct 9 Mon)
@@ -59,9 +65,8 @@ public class Issue228Test {
         assertEquals(ZonedDateTime.parse("2017-10-09T09:00-07:00"), ExecutionTime.forCron(myCron).nextExecution(time).get());
     }
 
-    //@Test
+    @Test
     public void testEveryWeekendForthWeekOfMonthNextExecution() {
-        CronDefinition cronDefinition = CronDefinitionBuilder.instanceDefinitionFor(CronType.UNIX);
         CronParser parser = new CronParser(cronDefinition);
 
         // This is 9am on Sat and Sun day between the 22nd and 28th (in this case it should be Oct 22)


### PR DESCRIPTION
Use a custom cron definition in Issue228Test that meets the issue expectations.