### PR TITLE
Fixes #200 where isMatch() ensures that the datetime is matched…

### DIFF
--- a/src/main/java/com/cronutils/model/time/ExecutionTime.java
+++ b/src/main/java/com/cronutils/model/time/ExecutionTime.java
@@ -499,7 +499,7 @@ public class ExecutionTime {
     public boolean isMatch(ZonedDateTime date){
         // Issue #200: Truncating the date to the least granular precision supported by different cron systems.
         // For Quartz, it's seconds while for Unix & Cron4J it's minutes.
-        boolean isSecondGranularity = cronDefinition.containsFieldDefinition(CronFieldName.SECOND);
+        boolean isSecondGranularity = cronDefinition.containsFieldDefinition(SECOND);
         if(isSecondGranularity) {
             date = date.truncatedTo(ChronoUnit.SECONDS);
         } else {

--- a/src/test/java/com/cronutils/Issue200Test.java
+++ b/src/test/java/com/cronutils/Issue200Test.java
@@ -16,8 +16,8 @@ import static org.junit.Assert.*;
  * Created by johnpatrick.manalo on 6/19/17.
  */
 public class Issue200Test {
-    // Does not pass!
-    //@Test
+
+    @Test
     public void testMustMatchCronEvenIfNanoSecondsVaries() {
         CronDefinition cronDefinition =
                 CronDefinitionBuilder.instanceDefinitionFor(QUARTZ);


### PR DESCRIPTION
… according to the granularity of the cron system.

For Quartz, the precision is seconds while for Unix crons & Cron4J, it's minutes.