### PR TITLE
Jdk8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -87,19 +87,6 @@
             <artifactId>commons-cli</artifactId>
             <version>${commonscli.version}</version>
         </dependency>
-        <dependency>
-            <groupId>org.threeten</groupId>
-            <artifactId>threetenbp</artifactId>
-            <version>1.3.3</version>
-	    <scope>compile</scope>
-	    <classifier>no-tzdb</classifier>
-        </dependency>
-        <dependency>
-            <groupId>org.threeten</groupId>
-            <artifactId>threetenbp</artifactId>
-            <version>1.3.3</version>
-            <scope>test</scope>
-        </dependency>
         <!--dependency>
             <groupId>eu.lp0.slf4j</groupId>
             <artifactId>slf4j-android</artifactId>
@@ -157,8 +144,8 @@
 				<artifactId>maven-compiler-plugin</artifactId>
 				<version>3.1</version>
 				<configuration>
-					<source>1.7</source>
-					<target>1.7</target>
+					<source>1.8</source>
+					<target>1.8</target>
 				</configuration>
 			</plugin>
 			<plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -270,19 +270,6 @@
 				</configuration>
 			</plugin>
 			<plugin>
-				<groupId>net.orfjackal.retrolambda</groupId>
-				<artifactId>retrolambda-maven-plugin</artifactId>
-				<version>2.5.1</version>
-				<executions>
-					<execution>
-						<goals>
-							<goal>process-main</goal>
-							<goal>process-test</goal>
-						</goals>
-					</execution>
-				</executions>
-			</plugin>
-			<plugin>
 				<groupId>org.apache.felix</groupId>
 				<artifactId>maven-bundle-plugin</artifactId>
 				<version>2.5.0</version>

--- a/src/androidTest/java/com/cronutils/Issue143Test.java
+++ b/src/androidTest/java/com/cronutils/Issue143Test.java
@@ -9,9 +9,9 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.threeten.bp.LocalDateTime;
-import org.threeten.bp.ZoneId;
-import org.threeten.bp.ZonedDateTime;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
 
 @RunWith(AndroidJUnit4.class)
 public class Issue143Test extends BaseAndroidTest {

--- a/src/androidTest/java/com/cronutils/Issue55UnexpectedExecutionTimes.java
+++ b/src/androidTest/java/com/cronutils/Issue55UnexpectedExecutionTimes.java
@@ -12,9 +12,9 @@ import com.cronutils.parser.CronParser;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.threeten.bp.Instant;
-import org.threeten.bp.ZoneOffset;
-import org.threeten.bp.ZonedDateTime;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/src/androidTest/java/com/cronutils/OpenIssuesTest.java
+++ b/src/androidTest/java/com/cronutils/OpenIssuesTest.java
@@ -8,8 +8,8 @@ import com.cronutils.model.time.ExecutionTime;
 import com.cronutils.parser.CronParser;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.threeten.bp.ZonedDateTime;
-import org.threeten.bp.format.DateTimeFormatter;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
 
 import java.text.ParseException;
 

--- a/src/androidTest/java/com/cronutils/model/time/ExecutionTimeCron4jIntegrationTest.java
+++ b/src/androidTest/java/com/cronutils/model/time/ExecutionTimeCron4jIntegrationTest.java
@@ -10,8 +10,8 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.threeten.bp.ZoneId;
-import org.threeten.bp.ZonedDateTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
 
 import static org.junit.Assert.*;
 

--- a/src/androidTest/java/com/cronutils/model/time/ExecutionTimeCustomDefinitionIntegrationTest.java
+++ b/src/androidTest/java/com/cronutils/model/time/ExecutionTimeCustomDefinitionIntegrationTest.java
@@ -9,12 +9,12 @@ import com.cronutils.parser.CronParser;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.threeten.bp.ZoneId;
-import org.threeten.bp.ZonedDateTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
-import static org.threeten.bp.ZoneOffset.UTC;
+import static java.time.ZoneOffset.UTC;
 
 @RunWith(AndroidJUnit4.class)
 public class ExecutionTimeCustomDefinitionIntegrationTest extends BaseAndroidTest {

--- a/src/androidTest/java/com/cronutils/model/time/ExecutionTimeQuartzIntegrationTest.java
+++ b/src/androidTest/java/com/cronutils/model/time/ExecutionTimeQuartzIntegrationTest.java
@@ -11,12 +11,12 @@ import com.google.common.base.Optional;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.threeten.bp.format.DateTimeFormatter;
-import org.threeten.bp.temporal.ChronoUnit;
+import java.time.format.DateTimeFormatter;
+import java.time.temporal.ChronoUnit;
 
 import static com.cronutils.model.CronType.QUARTZ;
 import static org.junit.Assert.*;
-import static org.threeten.bp.ZoneOffset.UTC;
+import static java.time.ZoneOffset.UTC;
 
 /*
  * Copyright 2015 jmrozanec

--- a/src/androidTest/java/com/cronutils/model/time/generator/ExecutionTimeUnixIntegrationTest.java
+++ b/src/androidTest/java/com/cronutils/model/time/generator/ExecutionTimeUnixIntegrationTest.java
@@ -11,10 +11,10 @@ import com.cronutils.parser.CronParser;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.threeten.bp.Duration;
-import org.threeten.bp.Instant;
-import org.threeten.bp.ZoneId;
-import org.threeten.bp.ZonedDateTime;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;

--- a/src/androidTest/java/com/cronutils/model/time/generator/OnDayOfMonthValueGeneratorLTest.java
+++ b/src/androidTest/java/com/cronutils/model/time/generator/OnDayOfMonthValueGeneratorLTest.java
@@ -11,7 +11,7 @@ import com.cronutils.model.field.value.SpecialCharFieldValue;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.threeten.bp.LocalDate;
+import java.time.LocalDate;
 
 import java.util.List;
 

--- a/src/androidTest/java/com/cronutils/parser/CronParserQuartzIntegrationTest.java
+++ b/src/androidTest/java/com/cronutils/parser/CronParserQuartzIntegrationTest.java
@@ -15,7 +15,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
-import org.threeten.bp.ZonedDateTime;
+import java.time.ZonedDateTime;
 
 import java.util.Locale;
 

--- a/src/androidTest/java/com/cronutils/validator/CronValidatorQuartzIntegrationTest.java
+++ b/src/androidTest/java/com/cronutils/validator/CronValidatorQuartzIntegrationTest.java
@@ -7,8 +7,8 @@ import com.cronutils.parser.CronParser;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.threeten.bp.LocalDate;
-import org.threeten.bp.format.DateTimeFormatter;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
 
 import java.util.Locale;
 

--- a/src/main/java/com/cronutils/descriptor/CronDescriptor.java
+++ b/src/main/java/com/cronutils/descriptor/CronDescriptor.java
@@ -125,7 +125,7 @@ public class CronDescriptor {
         String description = DescriptionStrategyFactory.daysOfWeekInstance(
 		        bundle,
 		        fields.containsKey(CronFieldName.DAY_OF_WEEK) ? fields.get(CronFieldName.DAY_OF_WEEK).getExpression() : null,
-		        definitions.containsKey(CronFieldName.DAY_OF_WEEK) ? definitions.get(CronFieldName.DAY_OF_WEEK) : null 
+		        definitions.containsKey(CronFieldName.DAY_OF_WEEK) ? definitions.get(CronFieldName.DAY_OF_WEEK) : null
 		).describe();
 		return this.addExpressions(description, bundle.getString("day"), bundle.getString("days"));
     }

--- a/src/main/java/com/cronutils/descriptor/DescriptionStrategy.java
+++ b/src/main/java/com/cronutils/descriptor/DescriptionStrategy.java
@@ -40,12 +40,7 @@ abstract class DescriptionStrategy {
 
 	public DescriptionStrategy(ResourceBundle bundle) {
 		this.bundle = bundle;
-		nominalValueFunction = new Function<Integer, String>() {
-			@Override
-			public String apply(Integer integer) {
-				return WHITE_SPACE + integer;
-			}
-		};
+		this.nominalValueFunction = integer -> WHITE_SPACE + integer;
 	}
 
 	/**

--- a/src/main/java/com/cronutils/descriptor/DescriptionStrategyFactory.java
+++ b/src/main/java/com/cronutils/descriptor/DescriptionStrategyFactory.java
@@ -2,9 +2,9 @@ package com.cronutils.descriptor;
 
 import java.util.ResourceBundle;
 
-import org.threeten.bp.DayOfWeek;
-import org.threeten.bp.Month;
-import org.threeten.bp.format.TextStyle;
+import java.time.DayOfWeek;
+import java.time.Month;
+import java.time.format.TextStyle;
 
 import com.cronutils.Function;
 import com.cronutils.model.field.definition.DayOfWeekFieldDefinition;

--- a/src/main/java/com/cronutils/descriptor/DescriptionStrategyFactory.java
+++ b/src/main/java/com/cronutils/descriptor/DescriptionStrategyFactory.java
@@ -36,32 +36,26 @@ class DescriptionStrategyFactory {
      */
     public static DescriptionStrategy daysOfWeekInstance(final ResourceBundle bundle, final FieldExpression expression, final FieldDefinition definition) {
         
-    	final Function<Integer, String> nominal = new Function<Integer, String>() {
-          @Override
-          public String apply(Integer integer) {
-              int diff = definition instanceof DayOfWeekFieldDefinition ? DayOfWeek.MONDAY.getValue() - ((DayOfWeekFieldDefinition) definition).getMondayDoWValue().getMondayDoWValue() : 0;
-              return DayOfWeek.of(integer + diff < 1 ? 7 : integer + diff).getDisplayName(TextStyle.FULL, bundle.getLocale());
-          }
-      };
+    	final Function<Integer, String> nominal = integer -> {
+            int diff = definition instanceof DayOfWeekFieldDefinition ? DayOfWeek.MONDAY.getValue() - ((DayOfWeekFieldDefinition) definition).getMondayDoWValue().getMondayDoWValue() : 0;
+            return DayOfWeek.of(integer + diff < 1 ? 7 : integer + diff).getDisplayName(TextStyle.FULL, bundle.getLocale());
+        };
         
         NominalDescriptionStrategy dow = new NominalDescriptionStrategy(bundle, nominal, expression);
 
-        dow.addDescription(new Function<FieldExpression, String>() {
-            @Override
-            public String apply(FieldExpression fieldExpression) {
-                if (fieldExpression instanceof On) {
-                    On on = (On) fieldExpression;
-                    switch (on.getSpecialChar().getValue()) {
-                        case HASH:
-                            return String.format("%s %s %s ", nominal.apply(on.getTime().getValue()), on.getNth(), bundle.getString("of_every_month"));
-                        case L:
-                            return String.format("%s %s %s ", bundle.getString("last"), nominal.apply(on.getTime().getValue()), bundle.getString("of_every_month"));
-                        default:
-                            return "";
-                    }
+        dow.addDescription(fieldExpression -> {
+            if (fieldExpression instanceof On) {
+                On on = (On) fieldExpression;
+                switch (on.getSpecialChar().getValue()) {
+                    case HASH:
+                        return String.format("%s %s %s ", nominal.apply(on.getTime().getValue()), on.getNth(), bundle.getString("of_every_month"));
+                    case L:
+                        return String.format("%s %s %s ", bundle.getString("last"), nominal.apply(on.getTime().getValue()), bundle.getString("of_every_month"));
+                    default:
+                        return "";
                 }
-                return "";
             }
+            return "";
         });
         return dow;
     }
@@ -75,24 +69,21 @@ class DescriptionStrategyFactory {
     public static DescriptionStrategy daysOfMonthInstance(final ResourceBundle bundle, final FieldExpression expression) {
         NominalDescriptionStrategy dom = new NominalDescriptionStrategy(bundle, null, expression);
 
-        dom.addDescription(new Function<FieldExpression, String>() {
-            @Override
-            public String apply(FieldExpression fieldExpression) {
-                if (fieldExpression instanceof On) {
-                    On on = (On) fieldExpression;
-                    switch (on.getSpecialChar().getValue()) {
-                        case W:
-                            return String.format("%s %s %s ", bundle.getString("the_nearest_weekday_to_the"), on.getTime().getValue(), bundle.getString("of_the_month"));
-                        case L:
-                            return bundle.getString("last_day_of_month");
-                        case LW:
-                            return bundle.getString("last_weekday_of_month");
-                        default:
-                            return "";
-                    }
+        dom.addDescription(fieldExpression -> {
+            if (fieldExpression instanceof On) {
+                On on = (On) fieldExpression;
+                switch (on.getSpecialChar().getValue()) {
+                    case W:
+                        return String.format("%s %s %s ", bundle.getString("the_nearest_weekday_to_the"), on.getTime().getValue(), bundle.getString("of_the_month"));
+                    case L:
+                        return bundle.getString("last_day_of_month");
+                    case LW:
+                        return bundle.getString("last_weekday_of_month");
+                    default:
+                        return "";
                 }
-                return "";
             }
+            return "";
         });
         return dom;
     }
@@ -106,12 +97,7 @@ class DescriptionStrategyFactory {
     public static DescriptionStrategy monthsInstance(final ResourceBundle bundle, final FieldExpression expression) {
         return new NominalDescriptionStrategy(
                 bundle,
-            new Function<Integer, String>() {
-                @Override
-                public String apply(Integer integer) {
-                    return Month.of(integer).getDisplayName(TextStyle.FULL, bundle.getLocale());
-                }
-            },
+                integer -> Month.of(integer).getDisplayName(TextStyle.FULL, bundle.getLocale()),
                 expression
         );
     }

--- a/src/main/java/com/cronutils/descriptor/TimeDescriptionStrategy.java
+++ b/src/main/java/com/cronutils/descriptor/TimeDescriptionStrategy.java
@@ -102,198 +102,174 @@ class TimeDescriptionStrategy extends DescriptionStrategy {
         //case: every second
         //case: every minute at x second
         descriptions.add(
-            new Function<TimeFields, String>() {
-              @Override
-              public String apply(TimeFields timeFields) {
-                if (timeFields.hours instanceof Always &&
-                    timeFields.minutes instanceof Always) {
-                  if (timeFields.seconds instanceof Always) {
-                    return String.format("%s %s ", bundle.getString("every"), bundle.getString("second"));
-                  }
-                  if (timeFields.seconds instanceof On) {
-                    if (TimeDescriptionStrategy.this.isDefault((On) timeFields.seconds)) {
-                      return String.format("%s %s ", bundle.getString("every"), bundle.getString("minute"));
-                    } else {
-                      return String.format("%s %s %s %s %02d", bundle.getString("every"),
-                          bundle.getString("minute"), bundle.getString("at"),
-                          bundle.getString("second"), ((On) timeFields.seconds).getTime().getValue());
+                timeFields -> {
+                  if (timeFields.hours instanceof Always &&
+                      timeFields.minutes instanceof Always) {
+                    if (timeFields.seconds instanceof Always) {
+                      return String.format("%s %s ", bundle.getString("every"), bundle.getString("second"));
+                    }
+                    if (timeFields.seconds instanceof On) {
+                      if (TimeDescriptionStrategy.this.isDefault((On) timeFields.seconds)) {
+                        return String.format("%s %s ", bundle.getString("every"), bundle.getString("minute"));
+                      } else {
+                        return String.format("%s %s %s %s %02d", bundle.getString("every"),
+                            bundle.getString("minute"), bundle.getString("at"),
+                            bundle.getString("second"), ((On) timeFields.seconds).getTime().getValue());
+                      }
                     }
                   }
-                }
-                return "";
-              }
-            });
+                  return "";
+                });
 
         //case: At minute x
         descriptions.add(
-            new Function<TimeFields, String>() {
-              @Override
-              public String apply(TimeFields timeFields) {
-                if (timeFields.hours instanceof Always &&
-                    timeFields.minutes instanceof On &&
-                    timeFields.seconds instanceof On) {
-                  if (TimeDescriptionStrategy.this.isDefault((On) timeFields.seconds)) {
-                    if (TimeDescriptionStrategy.this.isDefault((On) timeFields.minutes)) {
-                      return String.format("%s %s ", bundle.getString("every"), bundle.getString("hour"));
+                timeFields -> {
+                  if (timeFields.hours instanceof Always &&
+                      timeFields.minutes instanceof On &&
+                      timeFields.seconds instanceof On) {
+                    if (TimeDescriptionStrategy.this.isDefault((On) timeFields.seconds)) {
+                      if (TimeDescriptionStrategy.this.isDefault((On) timeFields.minutes)) {
+                        return String.format("%s %s ", bundle.getString("every"), bundle.getString("hour"));
+                      }
+                      return String.format("%s %s %s %s %s", bundle.getString("every"),
+                          bundle.getString("hour"), bundle.getString("at"),
+                          bundle.getString("minute"), ((On) timeFields.minutes).getTime().getValue());
+                    } else {
+                      return String.format("%s %s %s %s %s %s %s %s", bundle.getString("every"),
+                          bundle.getString("hour"), bundle.getString("at"),
+                          bundle.getString("minute"), ((On) timeFields.minutes).getTime().getValue(),
+                          bundle.getString("and"), bundle.getString("second"),
+                          ((On) timeFields.seconds).getTime().getValue());
                     }
-                    return String.format("%s %s %s %s %s", bundle.getString("every"),
-                        bundle.getString("hour"), bundle.getString("at"),
-                        bundle.getString("minute"), ((On) timeFields.minutes).getTime().getValue());
-                  } else {
-                    return String.format("%s %s %s %s %s %s %s %s", bundle.getString("every"),
-                        bundle.getString("hour"), bundle.getString("at"),
-                        bundle.getString("minute"), ((On) timeFields.minutes).getTime().getValue(),
-                        bundle.getString("and"), bundle.getString("second"),
-                        ((On) timeFields.seconds).getTime().getValue());
                   }
-                }
-                return "";
-              }
-            });
+                  return "";
+                });
 
         //case: 11:45
         descriptions.add(
-            new Function<TimeFields, String>() {
-              @Override
-              public String apply(TimeFields timeFields) {
-                if (timeFields.hours instanceof On &&
-                    timeFields.minutes instanceof On
-                    && timeFields.seconds instanceof Always) {
-                  return String.format("%s %s %s %02d:%02d", bundle.getString("every"),
-                      bundle.getString("second"), bundle.getString("at"),
-                      ((On) hours).getTime().getValue(), ((On) minutes).getTime().getValue());
-                }
-                return "";
-              }
-            });
+                timeFields -> {
+                  if (timeFields.hours instanceof On &&
+                      timeFields.minutes instanceof On
+                      && timeFields.seconds instanceof Always) {
+                    return String.format("%s %s %s %02d:%02d", bundle.getString("every"),
+                        bundle.getString("second"), bundle.getString("at"),
+                        ((On) hours).getTime().getValue(), ((On) minutes).getTime().getValue());
+                  }
+                  return "";
+                });
 
         //case: 11:30:45
         //case: 11:30:00 -> 11:30
         descriptions.add(
-            new Function<TimeFields, String>() {
-              @Override
-              public String apply(TimeFields timeFields) {
-                if (timeFields.hours instanceof On &&
-                    timeFields.minutes instanceof On
-                    && timeFields.seconds instanceof On) {
-                  if (TimeDescriptionStrategy.this.isDefault((On) timeFields.seconds)) {
-                    return String.format("%s %02d:%02d", bundle.getString("at"),
-                        ((On) hours).getTime().getValue(),
-                        ((On) minutes).getTime().getValue());
-                  } else {
-                    return String.format("%s %02d:%02d:%02d", bundle.getString("at"),
-                        ((On) hours).getTime().getValue(),
-                        ((On) minutes).getTime().getValue(), ((On) seconds).getTime().getValue());
+                timeFields -> {
+                  if (timeFields.hours instanceof On &&
+                      timeFields.minutes instanceof On
+                      && timeFields.seconds instanceof On) {
+                    if (TimeDescriptionStrategy.this.isDefault((On) timeFields.seconds)) {
+                      return String.format("%s %02d:%02d", bundle.getString("at"),
+                          ((On) hours).getTime().getValue(),
+                          ((On) minutes).getTime().getValue());
+                    } else {
+                      return String.format("%s %02d:%02d:%02d", bundle.getString("at"),
+                          ((On) hours).getTime().getValue(),
+                          ((On) minutes).getTime().getValue(), ((On) seconds).getTime().getValue());
+                    }
                   }
-                }
-                return "";
-              }
-            });
+                  return "";
+                });
 
         //11 -> 11:00
         descriptions.add(
-            new Function<TimeFields, String>() {
-              @Override
-              public String apply(TimeFields timeFields) {
-                if (timeFields.hours instanceof On &&
-                    timeFields.minutes instanceof Always &&
-                    timeFields.seconds instanceof Always) {
-                  return String.format("%s %02d:00", bundle.getString("at"), ((On) hours).getTime().getValue());
-                }
-                return "";
-              }
-            });
+                timeFields -> {
+                  if (timeFields.hours instanceof On &&
+                      timeFields.minutes instanceof Always &&
+                      timeFields.seconds instanceof Always) {
+                    return String.format("%s %02d:00", bundle.getString("at"), ((On) hours).getTime().getValue());
+                  }
+                  return "";
+                });
 
         //case: every minute between 11:00 and 11:10
         //case: every second between 11:00 and 11:10
         descriptions.add(
-            new Function<TimeFields, String>() {
-              @Override
-              public String apply(TimeFields timeFields) {
-                if (timeFields.hours instanceof On &&
-                    timeFields.minutes instanceof Between) {
-                  if (timeFields.seconds instanceof On) {
-                    return String.format("%s %s %s %02d:%02d %s %02d:%02d",
-                        bundle.getString("every"),
-                        bundle.getString("minute"),
-                        bundle.getString("between"),
-                        ((On) timeFields.hours).getTime().getValue(),
-                        ((Between) timeFields.minutes).getFrom().getValue(),
-                        bundle.getString("and"),
-                        ((On) timeFields.hours).getTime().getValue(),
-                        ((Between) timeFields.minutes).getTo().getValue());
+                timeFields -> {
+                  if (timeFields.hours instanceof On &&
+                      timeFields.minutes instanceof Between) {
+                    if (timeFields.seconds instanceof On) {
+                      return String.format("%s %s %s %02d:%02d %s %02d:%02d",
+                          bundle.getString("every"),
+                          bundle.getString("minute"),
+                          bundle.getString("between"),
+                          ((On) timeFields.hours).getTime().getValue(),
+                          ((Between) timeFields.minutes).getFrom().getValue(),
+                          bundle.getString("and"),
+                          ((On) timeFields.hours).getTime().getValue(),
+                          ((Between) timeFields.minutes).getTo().getValue());
+                    }
+                    if (timeFields.seconds instanceof Always) {
+                      return String.format("%s %s %s %02d:%02d %s %02d:%02d",
+                          bundle.getString("every"),
+                          bundle.getString("second"),
+                          bundle.getString("between"),
+                          ((On) timeFields.hours).getTime().getValue(),
+                          ((Between) timeFields.minutes).getFrom().getValue(),
+                          bundle.getString("and"),
+                          ((On) timeFields.hours).getTime().getValue(),
+                          ((Between) timeFields.minutes).getTo().getValue());
+                    }
                   }
-                  if (timeFields.seconds instanceof Always) {
-                    return String.format("%s %s %s %02d:%02d %s %02d:%02d",
-                        bundle.getString("every"),
-                        bundle.getString("second"),
-                        bundle.getString("between"),
-                        ((On) timeFields.hours).getTime().getValue(),
-                        ((Between) timeFields.minutes).getFrom().getValue(),
-                        bundle.getString("and"),
-                        ((On) timeFields.hours).getTime().getValue(),
-                        ((Between) timeFields.minutes).getTo().getValue());
-                  }
-                }
-                return "";
-              }
-            });
+                  return "";
+                });
 
         //case: every x minutes
         descriptions.add(
-            new Function<TimeFields, String>() {
-              @Override
-              public String apply(TimeFields timeFields) {
-                if (timeFields.hours instanceof Always &&
-                    timeFields.minutes instanceof Every &&
-                    timeFields.seconds instanceof On) {
-                  Every minute = (Every) timeFields.minutes;
-                  String desc;
-                  if (minute.getPeriod().getValue() == 1 &&
-                      TimeDescriptionStrategy.this.isDefault((On) timeFields.seconds)) {
-                    desc = String.format("%s %s", bundle.getString("every"), bundle.getString("minute"));
-                  } else {
-                    desc = String.format("%s %s %s ", bundle.getString("every"),
-                        minute.getPeriod().getValue(), bundle.getString("minutes"));
+                timeFields -> {
+                  if (timeFields.hours instanceof Always &&
+                      timeFields.minutes instanceof Every &&
+                      timeFields.seconds instanceof On) {
+                    Every minute = (Every) timeFields.minutes;
+                    String desc;
+                    if (minute.getPeriod().getValue() == 1 &&
+                        TimeDescriptionStrategy.this.isDefault((On) timeFields.seconds)) {
+                      desc = String.format("%s %s", bundle.getString("every"), bundle.getString("minute"));
+                    } else {
+                      desc = String.format("%s %s %s ", bundle.getString("every"),
+                          minute.getPeriod().getValue(), bundle.getString("minutes"));
+                    }
+                    if (minute.getExpression() instanceof Between) {
+                      return "";
+                    }
+                    return desc;
                   }
-                  if (minute.getExpression() instanceof Between) {
-                    return "";
-                  }
-                  return desc;
-                }
-                return "";
-              }
-            });
+                  return "";
+                });
 
         //case: every x hours
         descriptions.add(
-            new Function<TimeFields, String>() {
-              @Override
-              public String apply(TimeFields timeFields) {
-                if (timeFields.hours instanceof Every &&
-                    timeFields.minutes instanceof On &&
-                    timeFields.seconds instanceof On) {
-                  //every hour
-                  if (((On) timeFields.minutes).getTime().getValue() == 0 &&
-                      ((On) timeFields.seconds).getTime().getValue() == 0) {
-                    Integer period = ((Every) timeFields.hours).getPeriod().getValue();
-                    if (period == null || period == 1) {
-                      return String.format("%s %s", bundle.getString("every"), bundle.getString("hour"));
+                timeFields -> {
+                  if (timeFields.hours instanceof Every &&
+                      timeFields.minutes instanceof On &&
+                      timeFields.seconds instanceof On) {
+                    //every hour
+                    if (((On) timeFields.minutes).getTime().getValue() == 0 &&
+                        ((On) timeFields.seconds).getTime().getValue() == 0) {
+                      Integer period = ((Every) timeFields.hours).getPeriod().getValue();
+                      if (period == null || period == 1) {
+                        return String.format("%s %s", bundle.getString("every"), bundle.getString("hour"));
+                      }
+                    }
+                    String result = String.format("%s %s %s %s %s %s ",
+                        bundle.getString("every"), ((Every) hours).getPeriod().getValue(), bundle.getString("hours"),
+                        bundle.getString("at"), bundle.getString("minute"), ((On) minutes).getTime().getValue());
+                    if (TimeDescriptionStrategy.this.isDefault((On) timeFields.seconds)) {
+                      return result;
+                    } else {
+                      return String.format("%s %s %s", bundle.getString("and"),
+                          bundle.getString("second"), ((On) seconds).getTime().getValue());
                     }
                   }
-                  String result = String.format("%s %s %s %s %s %s ",
-                      bundle.getString("every"), ((Every) hours).getPeriod().getValue(), bundle.getString("hours"),
-                      bundle.getString("at"), bundle.getString("minute"), ((On) minutes).getTime().getValue());
-                  if (TimeDescriptionStrategy.this.isDefault((On) timeFields.seconds)) {
-                    return result;
-                  } else {
-                    return String.format("%s %s %s", bundle.getString("and"),
-                        bundle.getString("second"), ((On) seconds).getTime().getValue());
-                  }
-                }
-                return "";
-              }
-            });
+                  return "";
+                });
     }
 
 

--- a/src/main/java/com/cronutils/mapper/CronMapper.java
+++ b/src/main/java/com/cronutils/mapper/CronMapper.java
@@ -21,7 +21,6 @@ import com.cronutils.model.field.expression.FieldExpression;
 import com.cronutils.model.field.expression.On;
 import com.cronutils.model.field.expression.QuestionMark;
 import com.cronutils.model.field.expression.visitor.ValueMappingFieldExpressionVisitor;
-import com.cronutils.model.field.value.FieldValue;
 import com.cronutils.model.field.value.IntegerFieldValue;
 import com.cronutils.model.field.value.SpecialChar;
 import com.cronutils.utils.Preconditions;
@@ -118,40 +117,32 @@ public class CronMapper {
 
 
     private static Function<Cron, Cron> sameCron(){
-        return new Function<Cron, Cron>() {
-            @Override
-            public Cron apply(Cron cron) {
-                return cron;
-            }
-        };
+        return cron -> cron;
     }
 
     private static Function<Cron, Cron> setQuestionMark(){
-        return new Function<Cron, Cron>() {
-            @Override
-            public Cron apply(Cron cron) {
-                CronField dow = cron.retrieve(CronFieldName.DAY_OF_WEEK);
-                CronField dom = cron.retrieve(CronFieldName.DAY_OF_MONTH);
-                if (dow != null && dom != null) {
-                    if (dow.getExpression() instanceof QuestionMark || dom.getExpression() instanceof QuestionMark) {
-                        return cron;
+        return cron -> {
+            CronField dow = cron.retrieve(CronFieldName.DAY_OF_WEEK);
+            CronField dom = cron.retrieve(CronFieldName.DAY_OF_MONTH);
+            if (dow != null && dom != null) {
+                if (dow.getExpression() instanceof QuestionMark || dom.getExpression() instanceof QuestionMark) {
+                    return cron;
+                } else {
+                    Map<CronFieldName, CronField> fields = new HashMap<>();
+                    fields.putAll(cron.retrieveFieldsAsMap());
+                    if (dow.getExpression() instanceof Always) {
+                        fields.put(CronFieldName.DAY_OF_WEEK, new CronField(CronFieldName.DAY_OF_WEEK, new QuestionMark(), fields.get(CronFieldName.DAY_OF_WEEK).getConstraints()));
                     } else {
-                        Map<CronFieldName, CronField> fields = new HashMap<>();
-                        fields.putAll(cron.retrieveFieldsAsMap());
-                        if (dow.getExpression() instanceof Always) {
-                            fields.put(CronFieldName.DAY_OF_WEEK, new CronField(CronFieldName.DAY_OF_WEEK, new QuestionMark(), fields.get(CronFieldName.DAY_OF_WEEK).getConstraints()));
+                        if (dom.getExpression() instanceof Always) {
+                            fields.put(CronFieldName.DAY_OF_MONTH, new CronField(CronFieldName.DAY_OF_MONTH, new QuestionMark(), fields.get(CronFieldName.DAY_OF_MONTH).getConstraints()));
                         } else {
-                            if (dom.getExpression() instanceof Always) {
-                                fields.put(CronFieldName.DAY_OF_MONTH, new CronField(CronFieldName.DAY_OF_MONTH, new QuestionMark(), fields.get(CronFieldName.DAY_OF_MONTH).getConstraints()));
-                            } else {
-                                cron.validate();
-                            }
+                            cron.validate();
                         }
-                        return new Cron(cron.getCronDefinition(), new ArrayList<>(fields.values()));
                     }
+                    return new Cron(cron.getCronDefinition(), new ArrayList<>(fields.values()));
                 }
-                return cron;
             }
+            return cron;
         };
     }
 
@@ -218,12 +209,7 @@ public class CronMapper {
      */
     @VisibleForTesting
     static Function<CronField, CronField> returnSameExpression(){
-        return new Function<CronField, CronField>() {
-            @Override
-            public CronField apply(CronField field) {
-                return field;
-            }
-        };
+        return field -> field;
     }
 
     /**
@@ -233,12 +219,9 @@ public class CronMapper {
      */
     @VisibleForTesting
     static Function<CronField, CronField> returnOnZeroExpression(final CronFieldName name){
-        return new Function<CronField, CronField>() {
-            @Override
-            public CronField apply(CronField field) {
-                FieldConstraints constraints = FieldConstraintsBuilder.instance().forField(name).createConstraintsInstance();
-                return new CronField(name, new On(new IntegerFieldValue(0)), constraints);
-            }
+        return field -> {
+            FieldConstraints constraints = FieldConstraintsBuilder.instance().forField(name).createConstraintsInstance();
+            return new CronField(name, new On(new IntegerFieldValue(0)), constraints);
         };
     }
 
@@ -249,65 +232,51 @@ public class CronMapper {
      */
     @VisibleForTesting
     static Function<CronField, CronField> returnAlwaysExpression(final CronFieldName name){
-        return new Function<CronField, CronField>() {
-            @Override
-            public CronField apply(CronField field) {
-                return new CronField(name, new Always(), FieldConstraintsBuilder.instance().forField(name).createConstraintsInstance());
-            }
-        };
+        return field -> new CronField(name, new Always(), FieldConstraintsBuilder.instance().forField(name).createConstraintsInstance());
     }
 
 
     @VisibleForTesting
     static Function<CronField, CronField> dayOfWeekMapping(final DayOfWeekFieldDefinition sourceDef, final DayOfWeekFieldDefinition targetDef){
-        return new Function<CronField, CronField>() {
-            @Override
-            public CronField apply(CronField field) {
-                FieldExpression expression = field.getExpression();
-                FieldExpression dest = null;
-                dest = expression.accept(
-                    new ValueMappingFieldExpressionVisitor(
-                        new Function<FieldValue, FieldValue>() {
-                            @Override
-                            public FieldValue apply(FieldValue fieldValue) {
-                                if (fieldValue instanceof IntegerFieldValue) {
-                                    return new IntegerFieldValue(
-                                        ConstantsMapper.weekDayMapping(
-                                            sourceDef.getMondayDoWValue(),
-                                            targetDef.getMondayDoWValue(),
-                                            ((IntegerFieldValue) fieldValue).getValue()
-                                        )
-                                    );
-                                }
-                                return fieldValue;
+        return field -> {
+            FieldExpression expression = field.getExpression();
+            FieldExpression dest = null;
+            dest = expression.accept(
+                new ValueMappingFieldExpressionVisitor(
+                        fieldValue -> {
+                            if (fieldValue instanceof IntegerFieldValue) {
+                                return new IntegerFieldValue(
+                                    ConstantsMapper.weekDayMapping(
+                                        sourceDef.getMondayDoWValue(),
+                                        targetDef.getMondayDoWValue(),
+                                        ((IntegerFieldValue) fieldValue).getValue()
+                                    )
+                                );
                             }
+                            return fieldValue;
                         }
-                    )
-                );
-                if (expression instanceof QuestionMark) {
-                    if (!targetDef.getConstraints().getSpecialChars().contains(SpecialChar.QUESTION_MARK)) {
-                        dest = new Always();
-                    }
+                )
+            );
+            if (expression instanceof QuestionMark) {
+                if (!targetDef.getConstraints().getSpecialChars().contains(SpecialChar.QUESTION_MARK)) {
+                    dest = new Always();
                 }
-                return new CronField(CronFieldName.DAY_OF_WEEK, dest, targetDef.getConstraints());
             }
+            return new CronField(CronFieldName.DAY_OF_WEEK, dest, targetDef.getConstraints());
         };
     }
 
     @VisibleForTesting
     static Function<CronField, CronField> dayOfMonthMapping(final FieldDefinition sourceDef, final FieldDefinition targetDef){
-        return new Function<CronField, CronField>() {
-            @Override
-            public CronField apply(CronField field) {
-                FieldExpression expression = field.getExpression();
-                FieldExpression dest = expression;
-                if (expression instanceof QuestionMark) {
-                    if (!targetDef.getConstraints().getSpecialChars().contains(SpecialChar.QUESTION_MARK)) {
-                        dest = new Always();
-                    }
+        return field -> {
+            FieldExpression expression = field.getExpression();
+            FieldExpression dest = expression;
+            if (expression instanceof QuestionMark) {
+                if (!targetDef.getConstraints().getSpecialChars().contains(SpecialChar.QUESTION_MARK)) {
+                    dest = new Always();
                 }
-                return new CronField(CronFieldName.DAY_OF_MONTH, dest, targetDef.getConstraints());
             }
+            return new CronField(CronFieldName.DAY_OF_MONTH, dest, targetDef.getConstraints());
         };
     }
 }

--- a/src/main/java/com/cronutils/mapper/WeekDay.java
+++ b/src/main/java/com/cronutils/mapper/WeekDay.java
@@ -62,29 +62,26 @@ public class WeekDay implements Serializable {
     }
 
     private Function<Integer, Integer> bothSameStartOfRange(final int startRange, final int endRange, final WeekDay source, final WeekDay target){
-        return new Function<Integer, Integer>() {
-            @Override
-            public Integer apply(Integer integer) {
-                int diff = target.getMondayDoWValue() - source.getMondayDoWValue();
-                int result = integer;
-                if (diff == 0) {
-                    return integer;
-                }
-                if (diff < 0) {
-                    result = integer + diff;
-                    int distanceToStartRange = startRange - result;
-                    if (result < startRange) {
-                        result = endRange + 1 - distanceToStartRange;
-                    }
-                }
-                if (diff > 0) {
-                    result = integer + diff;
-                    if (result > endRange) {
-                        result -= endRange;
-                    }
-                }
-                return result;
+        return integer -> {
+            int diff = target.getMondayDoWValue() - source.getMondayDoWValue();
+            int result = integer;
+            if (diff == 0) {
+                return integer;
             }
+            if (diff < 0) {
+                result = integer + diff;
+                int distanceToStartRange = startRange - result;
+                if (result < startRange) {
+                    result = endRange + 1 - distanceToStartRange;
+                }
+            }
+            if (diff > 0) {
+                result = integer + diff;
+                if (result > endRange) {
+                    result -= endRange;
+                }
+            }
+            return result;
         };
     }
 }

--- a/src/main/java/com/cronutils/model/Cron.java
+++ b/src/main/java/com/cronutils/model/Cron.java
@@ -65,11 +65,11 @@ public class Cron implements Serializable {
 
     public String asString(){
         if(asString == null){
-            ArrayList<CronField> fields = new ArrayList<CronField>(this.fields.values());
-            Collections.sort(fields, CronField.createFieldComparator());
+            ArrayList<CronField> fields = new ArrayList<>(this.fields.values());
+            fields.sort(CronField.createFieldComparator());
             StringBuilder builder = new StringBuilder();
-            for(int j =0; j<fields.size(); j++){
-                builder.append(String.format("%s ", fields.get(j).getExpression().asString()));
+            for (CronField field : fields) {
+                builder.append(String.format("%s ", field.getExpression().asString()));
             }
             asString = builder.toString().trim();
         }

--- a/src/main/java/com/cronutils/model/CronType.java
+++ b/src/main/java/com/cronutils/model/CronType.java
@@ -17,5 +17,5 @@ package com.cronutils.model;
  * Enumerates names of cron implementations
  */
 public enum CronType {
-    CRON4J, QUARTZ, UNIX;
+    CRON4J, QUARTZ, UNIX
 }

--- a/src/main/java/com/cronutils/model/definition/CronDefinition.java
+++ b/src/main/java/com/cronutils/model/definition/CronDefinition.java
@@ -75,7 +75,7 @@ public class CronDefinition implements Serializable {
      * @return Set of FieldDefinition instances, never null.
      */
     public Set<FieldDefinition> getFieldDefinitions(){
-        return new HashSet<FieldDefinition>(fieldDefinitions.values());
+        return new HashSet<>(fieldDefinitions.values());
     }
 
     /**

--- a/src/main/java/com/cronutils/model/definition/CronDefinitionBuilder.java
+++ b/src/main/java/com/cronutils/model/definition/CronDefinitionBuilder.java
@@ -159,10 +159,10 @@ public class CronDefinitionBuilder {
      * @return returns CronDefinition instance, never null
      */
     public CronDefinition instance() {
-        Set<CronConstraint> validations = new HashSet<CronConstraint>();
+        Set<CronConstraint> validations = new HashSet<>();
         validations.addAll(cronConstraints);
         List<FieldDefinition> values = new ArrayList<>(fields.values());
-        Collections.sort(values, FieldDefinition.createFieldDefinitionComparator());
+        values.sort(FieldDefinition.createFieldDefinitionComparator());
         return new CronDefinition(values, validations, enforceStrictRanges, matchDayOfWeekAndDayOfMonth);
     }
 

--- a/src/main/java/com/cronutils/model/field/CronField.java
+++ b/src/main/java/com/cronutils/model/field/CronField.java
@@ -44,12 +44,7 @@ public class CronField implements Serializable {
     }
 
     public static Comparator<CronField> createFieldComparator() {
-        return new Comparator<CronField>() {
-            @Override
-            public int compare(CronField o1, CronField o2) {
-                return o1.getField().getOrder() - o2.getField().getOrder();
-            }
-        };
+        return Comparator.comparingInt(o -> o.getField().getOrder());
     }
     
     @Override

--- a/src/main/java/com/cronutils/model/field/CronFieldName.java
+++ b/src/main/java/com/cronutils/model/field/CronFieldName.java
@@ -27,7 +27,7 @@ public enum CronFieldName {
      * @param order - specified order between cron fields.
      *              Used to be able to compare fields and sort them
      */
-    private CronFieldName(int order) {
+    CronFieldName(int order) {
         this.order = order;
     }
 

--- a/src/main/java/com/cronutils/model/field/constraint/FieldConstraintsBuilder.java
+++ b/src/main/java/com/cronutils/model/field/constraint/FieldConstraintsBuilder.java
@@ -156,7 +156,7 @@ public class FieldConstraintsBuilder {
     public FieldConstraintsBuilder withShiftedStringMapping(int shiftSize){
         if (shiftSize > 0 || endRange < stringMapping.size())
             for(Entry<String, Integer> entry : stringMapping.entrySet()) {
-                int value = entry.getValue().intValue();
+                int value = entry.getValue();
                 value += shiftSize;
                 if(value > endRange) {
                     value -= stringMapping.size();
@@ -164,7 +164,7 @@ public class FieldConstraintsBuilder {
                 else if(value < startRange) {
                     value += (startRange - endRange);
                 }
-                stringMapping.put(entry.getKey(), Integer.valueOf(value));
+                stringMapping.put(entry.getKey(), value);
             }
         return this;
     }

--- a/src/main/java/com/cronutils/model/field/definition/FieldDefinition.java
+++ b/src/main/java/com/cronutils/model/field/definition/FieldDefinition.java
@@ -82,12 +82,7 @@ public class FieldDefinition implements Serializable {
      * @return Comparator for FieldDefinition instance, never null;
      */
     public static Comparator<FieldDefinition> createFieldDefinitionComparator() {
-        return new Comparator<FieldDefinition>() {
-            @Override
-            public int compare(FieldDefinition o1, FieldDefinition o2) {
-                return o1.getFieldName().getOrder() - o2.getFieldName().getOrder();
-            }
-        };
+        return Comparator.comparingInt(o -> o.getFieldName().getOrder());
     }
 }
 

--- a/src/main/java/com/cronutils/model/time/ExecutionTime.java
+++ b/src/main/java/com/cronutils/model/time/ExecutionTime.java
@@ -1,12 +1,5 @@
 package com.cronutils.model.time;
 
-import static com.cronutils.model.field.CronFieldName.DAY_OF_MONTH;
-import static com.cronutils.model.field.CronFieldName.DAY_OF_WEEK;
-import static com.cronutils.model.field.CronFieldName.HOUR;
-import static com.cronutils.model.field.CronFieldName.MINUTE;
-import static com.cronutils.model.field.CronFieldName.MONTH;
-import static com.cronutils.model.field.CronFieldName.SECOND;
-import static com.cronutils.model.field.CronFieldName.YEAR;
 import static com.cronutils.model.field.value.SpecialChar.QUESTION_MARK;
 import static com.cronutils.model.time.generator.FieldValueGeneratorFactory.createDayOfMonthValueGeneratorInstance;
 import static com.cronutils.model.time.generator.FieldValueGeneratorFactory.createDayOfWeekValueGeneratorInstance;
@@ -276,9 +269,9 @@ public class ExecutionTime {
     
     private ZonedDateTime toBeginOfNextMonth(final ZonedDateTime datetime) {
         final ZonedDateTime nextMonth = datetime.plusMonths(1);
-        final int lowestHour = hours.getValues().get(0).intValue();
-        final int lowestMinute = minutes.getValues().get(0).intValue();
-        final int lowestSecond = seconds.getValues().get(0).intValue();
+        final int lowestHour = hours.getValues().get(0);
+        final int lowestMinute = minutes.getValues().get(0);
+        final int lowestSecond = seconds.getValues().get(0);
         return ZonedDateTime.of(nextMonth.getYear(), nextMonth.getMonth().getValue(), 1, lowestHour, lowestMinute, lowestSecond, 0, nextMonth.getZone());
     }
 
@@ -474,10 +467,7 @@ public class ExecutionTime {
      */
     public Optional<Duration> timeToNextExecution(ZonedDateTime date){
         Optional<ZonedDateTime> next = nextExecution(date);
-        if(next.isPresent()){
-            return Optional.of(Duration.between(date, next.get()));
-        }
-        return Optional.empty();
+        return next.map(zonedDateTime -> Duration.between(date, zonedDateTime));
     }
 
     /**
@@ -505,10 +495,7 @@ public class ExecutionTime {
      */
     public Optional<Duration> timeFromLastExecution(ZonedDateTime date){
         Optional<ZonedDateTime> last = lastExecution(date);
-        if(last.isPresent()){
-            return Optional.of(Duration.between(last.get(), date));
-        }
-        return Optional.empty();
+        return last.map(zonedDateTime -> Duration.between(zonedDateTime, date));
     }
 
     /**

--- a/src/main/java/com/cronutils/model/time/ExecutionTime.java
+++ b/src/main/java/com/cronutils/model/time/ExecutionTime.java
@@ -10,7 +10,7 @@ import static com.cronutils.model.field.CronFieldName.YEAR;
 import static com.cronutils.model.field.value.SpecialChar.QUESTION_MARK;
 import static com.cronutils.model.time.generator.FieldValueGeneratorFactory.createDayOfMonthValueGeneratorInstance;
 import static com.cronutils.model.time.generator.FieldValueGeneratorFactory.createDayOfWeekValueGeneratorInstance;
-import static org.threeten.bp.temporal.TemporalAdjusters.lastDayOfMonth;
+import static java.time.temporal.TemporalAdjusters.lastDayOfMonth;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -20,12 +20,12 @@ import java.util.Map;
 import java.util.Set;
 
 import com.google.common.collect.Sets;
-import org.threeten.bp.Duration;
-import org.threeten.bp.LocalDate;
-import org.threeten.bp.LocalDateTime;
-import org.threeten.bp.ZoneId;
-import org.threeten.bp.ZonedDateTime;
-import org.threeten.bp.temporal.ChronoUnit;
+import java.time.Duration;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.temporal.ChronoUnit;
 
 import com.cronutils.mapper.WeekDay;
 import com.cronutils.model.Cron;

--- a/src/main/java/com/cronutils/model/time/ExecutionTime.java
+++ b/src/main/java/com/cronutils/model/time/ExecutionTime.java
@@ -40,7 +40,7 @@ import com.cronutils.model.time.generator.NoDaysForMonthException;
 import com.cronutils.model.time.generator.NoSuchValueException;
 import com.cronutils.utils.Preconditions;
 import com.cronutils.utils.VisibleForTesting;
-import com.google.common.base.Optional;
+import java.util.Optional;
 import com.google.common.collect.Range;
 import com.google.common.base.MoreObjects;
 
@@ -147,7 +147,7 @@ public class ExecutionTime {
             }
             return Optional.of(nextMatch);
         } catch (NoSuchValueException e) {
-            return Optional.absent();
+            return Optional.empty();
         }
     }
 
@@ -477,7 +477,7 @@ public class ExecutionTime {
         if(next.isPresent()){
             return Optional.of(Duration.between(date, next.get()));
         }
-        return Optional.absent();
+        return Optional.empty();
     }
 
     /**
@@ -494,7 +494,7 @@ public class ExecutionTime {
             }
             return Optional.of(previousMatch);
         } catch (NoSuchValueException e) {
-            return Optional.absent();
+            return Optional.empty();
         }
     }
 
@@ -508,7 +508,7 @@ public class ExecutionTime {
         if(last.isPresent()){
             return Optional.of(Duration.between(last.get(), date));
         }
-        return Optional.absent();
+        return Optional.empty();
     }
 
     /**

--- a/src/main/java/com/cronutils/model/time/TimeNode.java
+++ b/src/main/java/com/cronutils/model/time/TimeNode.java
@@ -50,7 +50,7 @@ class TimeNode {
      */
     @VisibleForTesting
     NearestValue getNearestForwardValue(int reference, int shiftsToApply){
-        List<Integer> values = new ArrayList<Integer>(this.values);
+        List<Integer> values = new ArrayList<>(this.values);
         int index=0;
         boolean foundGreater = false;
         AtomicInteger shift = new AtomicInteger(0);
@@ -87,7 +87,7 @@ class TimeNode {
      */
     @VisibleForTesting
     NearestValue getNearestBackwardValue(int reference, int shiftsToApply){
-        List<Integer> values = new ArrayList<Integer>(this.values);
+        List<Integer> values = new ArrayList<>(this.values);
         Collections.reverse(values);
         int index=0;
         boolean foundSmaller=false;

--- a/src/main/java/com/cronutils/model/time/generator/AndFieldValueGenerator.java
+++ b/src/main/java/com/cronutils/model/time/generator/AndFieldValueGenerator.java
@@ -38,16 +38,13 @@ class AndFieldValueGenerator extends FieldValueGenerator {
     public int generateNextValue(final int reference) throws NoSuchValueException {
         List<Integer> candidates =
                 computeCandidates(
-                    new Function<FieldValueGenerator, Integer>() {
-                        @Override
-                        public Integer apply(FieldValueGenerator fieldValueGenerator) {
+                        fieldValueGenerator -> {
                             try {
                                 return fieldValueGenerator.generateNextValue(reference);
                             } catch (NoSuchValueException e) {
                                 return NO_VALUE;
                             }
                         }
-                    }
                 );
         if(candidates.isEmpty()){
             throw new NoSuchValueException();
@@ -60,16 +57,13 @@ class AndFieldValueGenerator extends FieldValueGenerator {
     public int generatePreviousValue(final int reference) throws NoSuchValueException {
         List<Integer> candidates =
                 computeCandidates(
-                    new Function<FieldValueGenerator, Integer>() {
-                        @Override
-                        public Integer apply(FieldValueGenerator candidateGenerator) {
+                        candidateGenerator -> {
                             try {
                                 return candidateGenerator.generatePreviousValue(reference);
                             } catch (NoSuchValueException e) {
                                 return NO_VALUE;
                             }
                         }
-                    }
                 );
         if(candidates.isEmpty()){
             throw new NoSuchValueException();

--- a/src/main/java/com/cronutils/model/time/generator/BetweenDayOfWeekValueGenerator.java
+++ b/src/main/java/com/cronutils/model/time/generator/BetweenDayOfWeekValueGenerator.java
@@ -76,13 +76,11 @@ class BetweenDayOfWeekValueGenerator extends FieldValueGenerator {
         int endDayOfWeek = 0;
         Object obj = between.getFrom().getValue();
         if (obj instanceof Integer) {
-        	Integer i = (Integer)obj;
-        	startDayOfWeek = i.intValue();
+            startDayOfWeek = (Integer)obj;
         }
         obj = between.getTo().getValue();
         if (obj instanceof Integer) {
-        	Integer i = (Integer)obj;
-        	endDayOfWeek = i.intValue();
+            endDayOfWeek = (Integer)obj;
         }
         
         for (int i = startDayOfWeek; i <= endDayOfWeek; i++) {

--- a/src/main/java/com/cronutils/model/time/generator/BetweenDayOfWeekValueGenerator.java
+++ b/src/main/java/com/cronutils/model/time/generator/BetweenDayOfWeekValueGenerator.java
@@ -18,7 +18,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-import org.threeten.bp.LocalDate;
+import java.time.LocalDate;
 
 import com.cronutils.mapper.WeekDay;
 import com.cronutils.model.field.CronField;

--- a/src/main/java/com/cronutils/model/time/generator/EveryFieldValueGenerator.java
+++ b/src/main/java/com/cronutils/model/time/generator/EveryFieldValueGenerator.java
@@ -5,7 +5,7 @@ import java.util.List;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.threeten.bp.ZonedDateTime;
+import java.time.ZonedDateTime;
 
 import com.cronutils.model.field.CronField;
 import com.cronutils.model.field.expression.Between;

--- a/src/main/java/com/cronutils/model/time/generator/OnDayOfMonthValueGenerator.java
+++ b/src/main/java/com/cronutils/model/time/generator/OnDayOfMonthValueGenerator.java
@@ -1,7 +1,7 @@
 package com.cronutils.model.time.generator;
 
-import org.threeten.bp.DayOfWeek;
-import org.threeten.bp.LocalDate;
+import java.time.DayOfWeek;
+import java.time.LocalDate;
 
 import com.cronutils.model.field.CronField;
 import com.cronutils.model.field.CronFieldName;

--- a/src/main/java/com/cronutils/model/time/generator/OnDayOfWeekValueGenerator.java
+++ b/src/main/java/com/cronutils/model/time/generator/OnDayOfWeekValueGenerator.java
@@ -1,6 +1,6 @@
 package com.cronutils.model.time.generator;
-import org.threeten.bp.DayOfWeek;
-import org.threeten.bp.LocalDate;
+import java.time.DayOfWeek;
+import java.time.LocalDate;
 
 import com.cronutils.mapper.ConstantsMapper;
 import com.cronutils.mapper.WeekDay;

--- a/src/main/java/com/cronutils/parser/CronParserField.java
+++ b/src/main/java/com/cronutils/parser/CronParserField.java
@@ -94,12 +94,7 @@ public class CronParserField {
 	 * @return Comparator for CronField instance, never null.
 	 */
 	public static Comparator<CronParserField> createFieldTypeComparator() {
-		return new Comparator<CronParserField>() {
-			@Override
-			public int compare(CronParserField o1, CronParserField o2) {
-				return o1.getField().getOrder() - o2.getField().getOrder();
-			}
-		};
+		return Comparator.comparingInt(o -> o.getField().getOrder());
 	}
 	
 	@Override

--- a/src/test/java/com/cronutils/Issue143Test.java
+++ b/src/test/java/com/cronutils/Issue143Test.java
@@ -35,7 +35,7 @@ public class Issue143Test {
         Assert.assertEquals(expected, actual);
     }
     
-//    @Test
+    @Test
     public void testCase2() {
         ExecutionTime et = ExecutionTime.forCron(parser.parse("0 0 12 ? 12 SAT#5 *"));
         ZonedDateTime actual = et.lastExecution(currentDateTime).get();
@@ -50,12 +50,12 @@ public class Issue143Test {
         ExecutionTime et = ExecutionTime.forCron(parser.parse("0 0 12 31 1/1 ? *"));
         ZonedDateTime actual = et.lastExecution(currentDateTime).get();
         
-        ZonedDateTime expected = ZonedDateTime.of(LocalDateTime.of(2015, 12, 31, 12, 00), 
+        ZonedDateTime expected = ZonedDateTime.of(LocalDateTime.of(2015, 12, 31, 12, 00),
                 ZoneId.systemDefault());
         Assert.assertEquals(expected, actual);
     }
     
-//    @Test
+    @Test
     public void testCase4() {
         ExecutionTime et = ExecutionTime.forCron(parser.parse("0 0 12 ? 1/1 SAT#5 *"));
         ZonedDateTime actual = et.lastExecution(currentDateTime).get();

--- a/src/test/java/com/cronutils/Issue143Test.java
+++ b/src/test/java/com/cronutils/Issue143Test.java
@@ -3,9 +3,9 @@ package com.cronutils;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
-import org.threeten.bp.LocalDateTime;
-import org.threeten.bp.ZoneId;
-import org.threeten.bp.ZonedDateTime;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
 
 import com.cronutils.model.CronType;
 import com.cronutils.model.definition.CronDefinitionBuilder;

--- a/src/test/java/com/cronutils/Issue200Test.java
+++ b/src/test/java/com/cronutils/Issue200Test.java
@@ -6,8 +6,8 @@ import com.cronutils.model.definition.CronDefinitionBuilder;
 import com.cronutils.model.time.ExecutionTime;
 import com.cronutils.parser.CronParser;
 import org.junit.*;
-import org.threeten.bp.ZoneId;
-import org.threeten.bp.ZonedDateTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
 
 import static com.cronutils.model.CronType.QUARTZ;
 import static org.junit.Assert.*;

--- a/src/test/java/com/cronutils/Issue215Test.java
+++ b/src/test/java/com/cronutils/Issue215Test.java
@@ -13,10 +13,10 @@ import com.cronutils.model.definition.CronDefinitionBuilder;
 import com.cronutils.model.time.ExecutionTime;
 import com.cronutils.parser.CronParser;
 import com.google.common.base.Optional;
-import org.threeten.bp.LocalDateTime;
-import org.threeten.bp.Month;
-import org.threeten.bp.ZoneId;
-import org.threeten.bp.ZonedDateTime;
+import java.time.LocalDateTime;
+import java.time.Month;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
 
 public class Issue215Test {
 

--- a/src/test/java/com/cronutils/Issue215Test.java
+++ b/src/test/java/com/cronutils/Issue215Test.java
@@ -12,7 +12,7 @@ import com.cronutils.model.CronType;
 import com.cronutils.model.definition.CronDefinitionBuilder;
 import com.cronutils.model.time.ExecutionTime;
 import com.cronutils.parser.CronParser;
-import com.google.common.base.Optional;
+import java.util.Optional;
 import java.time.LocalDateTime;
 import java.time.Month;
 import java.time.ZoneId;

--- a/src/test/java/com/cronutils/Issue215Test.java
+++ b/src/test/java/com/cronutils/Issue215Test.java
@@ -1,6 +1,3 @@
-/**
- * 
- */
 package com.cronutils;
 
 import static org.junit.Assert.*;

--- a/src/test/java/com/cronutils/Issue218Test.java
+++ b/src/test/java/com/cronutils/Issue218Test.java
@@ -5,7 +5,7 @@ import com.cronutils.model.definition.CronDefinition;
 import com.cronutils.model.time.ExecutionTime;
 import com.cronutils.parser.CronParser;
 import org.junit.Test;
-import org.threeten.bp.ZonedDateTime;
+import java.time.ZonedDateTime;
 
 import static com.cronutils.model.definition.CronDefinitionBuilder.defineCron;
 

--- a/src/test/java/com/cronutils/Issue223Test.java
+++ b/src/test/java/com/cronutils/Issue223Test.java
@@ -7,7 +7,7 @@ import com.cronutils.model.definition.CronDefinitionBuilder;
 import com.cronutils.model.time.ExecutionTime;
 import com.cronutils.parser.CronParser;
 import org.junit.Test;
-import org.threeten.bp.ZonedDateTime;
+import java.time.ZonedDateTime;
 
 import static org.junit.Assert.assertEquals;
 

--- a/src/test/java/com/cronutils/Issue228Test.java
+++ b/src/test/java/com/cronutils/Issue228Test.java
@@ -8,7 +8,6 @@ import com.cronutils.parser.CronParser;
 import org.junit.Test;
 import java.time.ZonedDateTime;
 
-import org.junit.Before;
 import static org.junit.Assert.assertEquals;
 
 public class Issue228Test {

--- a/src/test/java/com/cronutils/Issue228Test.java
+++ b/src/test/java/com/cronutils/Issue228Test.java
@@ -6,7 +6,7 @@ import com.cronutils.model.definition.CronDefinitionBuilder;
 import com.cronutils.model.time.ExecutionTime;
 import com.cronutils.parser.CronParser;
 import org.junit.Test;
-import org.threeten.bp.ZonedDateTime;
+import java.time.ZonedDateTime;
 
 import org.junit.Before;
 import static org.junit.Assert.assertEquals;

--- a/src/test/java/com/cronutils/Issue55UnexpectedExecutionTimes.java
+++ b/src/test/java/com/cronutils/Issue55UnexpectedExecutionTimes.java
@@ -7,9 +7,9 @@ import java.util.List;
 
 import org.junit.Before;
 import org.junit.Test;
-import org.threeten.bp.Instant;
-import org.threeten.bp.ZoneOffset;
-import org.threeten.bp.ZonedDateTime;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
 
 import com.cronutils.model.Cron;
 import com.cronutils.model.definition.CronConstraint;

--- a/src/test/java/com/cronutils/OpenIssuesTest.java
+++ b/src/test/java/com/cronutils/OpenIssuesTest.java
@@ -3,8 +3,8 @@ package com.cronutils;
 import java.text.ParseException;
 
 import org.junit.Test;
-import org.threeten.bp.ZonedDateTime;
-import org.threeten.bp.format.DateTimeFormatter;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
 
 import com.cronutils.model.Cron;
 import com.cronutils.model.CronType;

--- a/src/test/java/com/cronutils/model/definition/CronDefinitionBuilderTest.java
+++ b/src/test/java/com/cronutils/model/definition/CronDefinitionBuilderTest.java
@@ -13,7 +13,6 @@ import com.cronutils.model.CronType;
 import com.cronutils.model.field.CronFieldName;
 import com.cronutils.model.field.constraint.FieldConstraints;
 import com.cronutils.model.field.definition.FieldDefinition;
-import com.cronutils.model.field.value.SpecialChar;
 import com.cronutils.parser.CronParser;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
@@ -112,9 +111,9 @@ public class CronDefinitionBuilderTest {
                 new FieldDefinition(
                     CronFieldName.SECOND,
                     new FieldConstraints(
-                            Maps.<String, Integer>newHashMap(),
-                            Maps.<Integer, Integer>newHashMap(),
-                            Sets.<SpecialChar>newHashSet(),0, 1)
+                            Maps.newHashMap(),
+                            Maps.newHashMap(),
+                            Sets.newHashSet(),0, 1)
         );
         builder.register(testFieldDefinition);
         Set<FieldDefinition> definitions = builder.instance().getFieldDefinitions();

--- a/src/test/java/com/cronutils/model/definition/CronDefinitionTest.java
+++ b/src/test/java/com/cronutils/model/definition/CronDefinitionTest.java
@@ -14,8 +14,7 @@ import org.mockito.MockitoAnnotations;
 
 import com.cronutils.model.field.CronFieldName;
 import com.cronutils.model.field.definition.FieldDefinition;
-import com.google.common.collect.Lists;
-import com.google.common.collect.Sets;
+
 /*
  * Copyright 2015 jmrozanec
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -59,44 +58,44 @@ public class CronDefinitionTest {
 
     @Test(expected = NullPointerException.class)
     public void testConstructorNullFieldsParameter() throws Exception {
-        new CronDefinition(null, new HashSet<CronConstraint>(), enforceStrictRange, matchDayOfWeekAndDayOfMonth);
+        new CronDefinition(null, new HashSet<>(), enforceStrictRange, matchDayOfWeekAndDayOfMonth);
     }
 
     @Test(expected = NullPointerException.class)
     public void testConstructorNullConstraintsParameter() throws Exception {
-        new CronDefinition(new ArrayList<FieldDefinition>(), null, enforceStrictRange, matchDayOfWeekAndDayOfMonth);
+        new CronDefinition(new ArrayList<>(), null, enforceStrictRange, matchDayOfWeekAndDayOfMonth);
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void testConstructorEmptyFieldsParameter() throws Exception {
-        new CronDefinition(new ArrayList<FieldDefinition>(), new HashSet<CronConstraint>(), enforceStrictRange, matchDayOfWeekAndDayOfMonth);
+        new CronDefinition(new ArrayList<>(), new HashSet<>(), enforceStrictRange, matchDayOfWeekAndDayOfMonth);
     }
 
     @Test
     public void testLastFieldOptionalTrueWhenSet() throws Exception {
-        List<FieldDefinition> fields = Lists.newArrayList();
+        List<FieldDefinition> fields = new ArrayList<>();
         fields.add(mockFieldDefinition1);
         fields.add(mockFieldDefinition2);
         fields.add(mockFieldDefinition3optional);
-        Set<FieldDefinition> fieldDefinitions = new CronDefinition(fields, new HashSet<CronConstraint>(), enforceStrictRange, matchDayOfWeekAndDayOfMonth)
+        Set<FieldDefinition> fieldDefinitions = new CronDefinition(fields, new HashSet<>(), enforceStrictRange, matchDayOfWeekAndDayOfMonth)
             .getFieldDefinitions();
         List<FieldDefinition> sortedFieldDefinitions = new ArrayList<>(fieldDefinitions);
-        Collections.sort(sortedFieldDefinitions, FieldDefinition.createFieldDefinitionComparator());
+        sortedFieldDefinitions.sort(FieldDefinition.createFieldDefinitionComparator());
         assertTrue(sortedFieldDefinitions.get(fields.size()-1).isOptional());
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void testLastFieldOptionalNotAllowedOnSingleFieldDefinition() throws Exception {
-        List<FieldDefinition> fields = Lists.newArrayList();
+        List<FieldDefinition> fields = new ArrayList<>();
         fields.add(mockFieldDefinition3optional);
-        new CronDefinition(fields, new HashSet<CronConstraint>(), enforceStrictRange, matchDayOfWeekAndDayOfMonth);
+        new CronDefinition(fields, new HashSet<>(), enforceStrictRange, matchDayOfWeekAndDayOfMonth);
     }
 
     @Test
     public void testGetFieldDefinitions() throws Exception {
-        List<FieldDefinition> fields = Lists.newArrayList();
+        List<FieldDefinition> fields = new ArrayList<>();
         fields.add(mockFieldDefinition1);
-        CronDefinition cronDefinition = new CronDefinition(fields, new HashSet<CronConstraint>(), enforceStrictRange, matchDayOfWeekAndDayOfMonth);
+        CronDefinition cronDefinition = new CronDefinition(fields, new HashSet<>(), enforceStrictRange, matchDayOfWeekAndDayOfMonth);
         assertNotNull(cronDefinition.getFieldDefinitions());
         assertEquals(1, cronDefinition.getFieldDefinitions().size());
         assertTrue(cronDefinition.getFieldDefinitions().contains(mockFieldDefinition1));

--- a/src/test/java/com/cronutils/model/field/expression/visitor/ValueMappingFieldExpressionVisitorTest.java
+++ b/src/test/java/com/cronutils/model/field/expression/visitor/ValueMappingFieldExpressionVisitorTest.java
@@ -14,12 +14,7 @@ public class ValueMappingFieldExpressionVisitorTest {
 
     @Before
     public void setUp() throws Exception {
-        Function<FieldValue, FieldValue> transform = new Function<FieldValue, FieldValue>() {
-            @Override
-            public FieldValue apply(FieldValue input) {
-                return input;
-            }
-        };
+        Function<FieldValue, FieldValue> transform = input -> input;
         this.valueMappingFieldExpressionVisitor = new ValueMappingFieldExpressionVisitor(transform);
     }
 

--- a/src/test/java/com/cronutils/model/time/ExecutionTimeCron4jIntegrationTest.java
+++ b/src/test/java/com/cronutils/model/time/ExecutionTimeCron4jIntegrationTest.java
@@ -9,10 +9,10 @@ import org.junit.Before;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.threeten.bp.DayOfWeek;
-import org.threeten.bp.Month;
-import org.threeten.bp.ZoneId;
-import org.threeten.bp.ZonedDateTime;
+import java.time.DayOfWeek;
+import java.time.Month;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
 
 import com.cronutils.model.CronType;
 import com.cronutils.model.definition.CronDefinitionBuilder;

--- a/src/test/java/com/cronutils/model/time/ExecutionTimeCron4jIntegrationTest.java
+++ b/src/test/java/com/cronutils/model/time/ExecutionTimeCron4jIntegrationTest.java
@@ -4,7 +4,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
 
-import com.google.common.base.Optional;
+import java.util.Optional;
 import org.junit.Before;
 import org.junit.Test;
 import org.slf4j.Logger;

--- a/src/test/java/com/cronutils/model/time/ExecutionTimeCustomDefinitionIntegrationTest.java
+++ b/src/test/java/com/cronutils/model/time/ExecutionTimeCustomDefinitionIntegrationTest.java
@@ -2,11 +2,11 @@ package com.cronutils.model.time;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
-import static org.threeten.bp.ZoneOffset.UTC;
+import static java.time.ZoneOffset.UTC;
 
 import org.junit.Test;
-import org.threeten.bp.ZoneId;
-import org.threeten.bp.ZonedDateTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
 
 import com.cronutils.model.Cron;
 import com.cronutils.model.definition.CronDefinition;

--- a/src/test/java/com/cronutils/model/time/ExecutionTimeQuartzIntegrationTest.java
+++ b/src/test/java/com/cronutils/model/time/ExecutionTimeQuartzIntegrationTest.java
@@ -4,7 +4,7 @@ import com.cronutils.model.Cron;
 import com.cronutils.model.definition.CronDefinition;
 import com.cronutils.model.definition.CronDefinitionBuilder;
 import com.cronutils.parser.CronParser;
-import com.google.common.base.Optional;
+import java.util.Optional;
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;

--- a/src/test/java/com/cronutils/model/time/ExecutionTimeQuartzIntegrationTest.java
+++ b/src/test/java/com/cronutils/model/time/ExecutionTimeQuartzIntegrationTest.java
@@ -8,14 +8,16 @@ import com.google.common.base.Optional;
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
-import org.threeten.bp.*;
-import org.threeten.bp.format.DateTimeFormatter;
-import org.threeten.bp.temporal.ChronoUnit;
+import java.time.*;
+import java.time.format.DateTimeFormatter;
+import java.time.temporal.ChronoUnit;
 
 import java.util.Date;
+import java.util.TimeZone;
+
 import static com.cronutils.model.CronType.QUARTZ;
 import static org.junit.Assert.*;
-import static org.threeten.bp.ZoneOffset.UTC;
+import static java.time.ZoneOffset.UTC;
 
 /*
  * Copyright 2015 jmrozanec
@@ -570,10 +572,10 @@ public class ExecutionTimeQuartzIntegrationTest {
         ZonedDateTime cronUtilsNextTime = ExecutionTime.forCron(cron).nextExecution(date).get();// 2016-12-30T00:00:00Z
 
         org.quartz.CronExpression cronExpression = new org.quartz.CronExpression(cron.asString());
-        cronExpression.setTimeZone(DateTimeUtils.toTimeZone(utc));
-        Date quartzNextTime = cronExpression.getNextValidTimeAfter(DateTimeUtils.toDate(date.toInstant()));// 2016-12-24T00:00:00Z
+        cronExpression.setTimeZone(TimeZone.getTimeZone(utc));
+        Date quartzNextTime = cronExpression.getNextValidTimeAfter(Date.from(date.toInstant()));// 2016-12-24T00:00:00Z
 
-        assertEquals(expected.toInstant(), DateTimeUtils.toInstant(quartzNextTime));    // test the reference implementation
+        assertEquals(expected.toInstant(), quartzNextTime.toInstant());    // test the reference implementation
         assertEquals(expected.toInstant(), cronUtilsNextTime.toInstant()); // and compare with cronUtils
     }
 

--- a/src/test/java/com/cronutils/model/time/ExecutionTimeQuartzWithDayOfYearExtensionIntegrationTest.java
+++ b/src/test/java/com/cronutils/model/time/ExecutionTimeQuartzWithDayOfYearExtensionIntegrationTest.java
@@ -1,7 +1,7 @@
 package com.cronutils.model.time;
 
 import static org.junit.Assert.assertEquals;
-import static org.threeten.bp.ZoneOffset.UTC;
+import static java.time.ZoneOffset.UTC;
 
 import com.cronutils.model.CronType;
 import com.cronutils.model.definition.CronDefinitionBuilder;
@@ -10,9 +10,9 @@ import com.cronutils.parser.CronParser;
 
 import org.junit.Before;
 import org.junit.Test;
-import org.threeten.bp.ZoneId;
-import org.threeten.bp.ZonedDateTime;
-import org.threeten.bp.temporal.ChronoUnit;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.temporal.ChronoUnit;
 
 import java.util.stream.IntStream;
 

--- a/src/test/java/com/cronutils/model/time/ExecutionTimeQuartzWithDayOfYearExtensionIntegrationTest.java
+++ b/src/test/java/com/cronutils/model/time/ExecutionTimeQuartzWithDayOfYearExtensionIntegrationTest.java
@@ -14,8 +14,6 @@ import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.time.temporal.ChronoUnit;
 
-import java.util.stream.IntStream;
-
 
 /*
  * Copyright 2015 jmrozanec Licensed under the Apache License, Version 2.0 (the

--- a/src/test/java/com/cronutils/model/time/TimeNodeTest.java
+++ b/src/test/java/com/cronutils/model/time/TimeNodeTest.java
@@ -2,13 +2,14 @@ package com.cronutils.model.time;
 
 import static org.junit.Assert.assertEquals;
 
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.junit.Before;
 import org.junit.Test;
 
-import com.google.common.collect.Lists;
 /*
  * Copyright 2015 jmrozanec
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -32,7 +33,7 @@ public class TimeNodeTest {
 
     @Before
     public void setUp() throws Exception {
-        values = Lists.newArrayList();
+        values = new ArrayList<>();
         values.add(LIST_START_VALUE);
         values.add(LIST_MEDIUM_VALUE);
         values.add(LIST_END_VALUE);
@@ -78,7 +79,7 @@ public class TimeNodeTest {
         int index = -1;
         int expectedShifts = 1;
         AtomicInteger shift = new AtomicInteger(0);
-        List<Integer> list = Lists.newArrayList(1, 2, 3, 4);
+        List<Integer> list = Arrays.asList(1, 2, 3, 4);
         int value = timeNode.getValueFromList(list, index, shift);
         assertEquals(String.format("Shift was: %s; expected: %s", shift.get(), expectedShifts), expectedShifts, shift.get());
         assertEquals((int)list.get(list.size()+index), value);
@@ -89,7 +90,7 @@ public class TimeNodeTest {
         int index = 1;
         int expectedShifts = 0;
         AtomicInteger shift = new AtomicInteger(0);
-        List<Integer> list = Lists.newArrayList(1, 2, 3, 4);
+        List<Integer> list = Arrays.asList(1, 2, 3, 4);
         int value = timeNode.getValueFromList(list, index, shift);
         assertEquals(String.format("Shift was: %s; expected: %s", shift.get(), expectedShifts), expectedShifts, shift.get());
         assertEquals((int)list.get(index), value);
@@ -97,7 +98,7 @@ public class TimeNodeTest {
 
     @Test(expected = IllegalArgumentException.class)
     public void testGetValueFromListWithEmptyList(){
-        timeNode.getValueFromList(Lists.<Integer>newArrayList(), 0, new AtomicInteger(0));
+        timeNode.getValueFromList(new ArrayList<>(), 0, new AtomicInteger(0));
     }
 
     private void assertResult(int value, int shift, NearestValue nearestValue){

--- a/src/test/java/com/cronutils/model/time/generator/ExecutionTimeUnixIntegrationTest.java
+++ b/src/test/java/com/cronutils/model/time/generator/ExecutionTimeUnixIntegrationTest.java
@@ -2,7 +2,7 @@ package com.cronutils.model.time.generator;
 
 import com.google.common.base.Optional;
 import org.junit.Test;
-import org.threeten.bp.*;
+import java.time.*;
 
 import com.cronutils.model.Cron;
 import com.cronutils.model.CronType;

--- a/src/test/java/com/cronutils/model/time/generator/ExecutionTimeUnixIntegrationTest.java
+++ b/src/test/java/com/cronutils/model/time/generator/ExecutionTimeUnixIntegrationTest.java
@@ -1,6 +1,5 @@
 package com.cronutils.model.time.generator;
 
-import java.util.Optional;
 import org.junit.Test;
 import java.time.*;
 

--- a/src/test/java/com/cronutils/model/time/generator/ExecutionTimeUnixIntegrationTest.java
+++ b/src/test/java/com/cronutils/model/time/generator/ExecutionTimeUnixIntegrationTest.java
@@ -1,6 +1,6 @@
 package com.cronutils.model.time.generator;
 
-import com.google.common.base.Optional;
+import java.util.Optional;
 import org.junit.Test;
 import java.time.*;
 

--- a/src/test/java/com/cronutils/model/time/generator/OnDayOfMonthValueGeneratorLTest.java
+++ b/src/test/java/com/cronutils/model/time/generator/OnDayOfMonthValueGeneratorLTest.java
@@ -8,7 +8,7 @@ import java.util.List;
 
 import org.junit.Before;
 import org.junit.Test;
-import org.threeten.bp.LocalDate;
+import java.time.LocalDate;
 
 import com.cronutils.model.field.CronField;
 import com.cronutils.model.field.CronFieldName;

--- a/src/test/java/com/cronutils/parser/CronParserQuartzIntegrationTest.java
+++ b/src/test/java/com/cronutils/parser/CronParserQuartzIntegrationTest.java
@@ -9,7 +9,7 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
-import org.threeten.bp.ZonedDateTime;
+import java.time.ZonedDateTime;
 
 import com.cronutils.builder.CronBuilder;
 import com.cronutils.descriptor.CronDescriptor;

--- a/src/test/java/com/cronutils/utils/descriptor/Issue227Test.java
+++ b/src/test/java/com/cronutils/utils/descriptor/Issue227Test.java
@@ -7,9 +7,9 @@ import com.cronutils.model.definition.CronDefinitionBuilder;
 import com.cronutils.parser.CronParser;
 import org.junit.Before;
 import org.junit.Test;
-import org.threeten.bp.LocalDateTime;
-import org.threeten.bp.ZoneId;
-import org.threeten.bp.ZonedDateTime;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
 
 import java.util.Locale;
 

--- a/src/test/java/com/cronutils/validator/CronValidatorQuartzIntegrationTest.java
+++ b/src/test/java/com/cronutils/validator/CronValidatorQuartzIntegrationTest.java
@@ -6,8 +6,8 @@ import java.util.Locale;
 
 import org.junit.Before;
 import org.junit.Test;
-import org.threeten.bp.LocalDate;
-import org.threeten.bp.format.DateTimeFormatter;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
 
 import com.cronutils.model.CronType;
 import com.cronutils.model.definition.CronDefinitionBuilder;


### PR DESCRIPTION
Fixes #175 and #254 
* Lift baseline to jdk8 and migrate org.threeten.bp to java.time
* Migrate com.google.common.base.Optional to java.util.Optional
* Migrate code formatting to jdk8
  * Inferred generic types e.g. new ArrayList<>()
  * Remove redundant boxing and unboxing of primitives
  * Replace Collections.sort(l, c) with list.sort(c)
  * Replace Anonymous Inner Class with lambda
  * Remove unused imports
* Remove RetroLambda Maven Plugin