### PR TITLE
Restructure large methods in ExecutionTime

### DIFF
--- a/src/main/java/com/cronutils/utils/Predicates.java
+++ b/src/main/java/com/cronutils/utils/Predicates.java
@@ -1,0 +1,10 @@
+package com.cronutils.utils;
+
+import java.util.function.Predicate;
+
+public class Predicates {
+
+    public static <T> Predicate<T> not(Predicate<T> t) {
+        return t.negate();
+    }
+}

--- a/src/test/java/com/cronutils/OpenIssuesTest.java
+++ b/src/test/java/com/cronutils/OpenIssuesTest.java
@@ -3,6 +3,7 @@ package com.cronutils;
 import java.text.ParseException;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
+import java.util.Locale;
 
 import org.junit.Test;
 
@@ -13,8 +14,8 @@ import com.cronutils.model.time.ExecutionTime;
 import com.cronutils.parser.CronParser;
 
 public class OpenIssuesTest {
-    private DateTimeFormatter dfSimple = DateTimeFormatter.ofPattern("hh:mm:ss MM/dd/yyyy a X");
-    private DateTimeFormatter df = DateTimeFormatter.ofPattern("hh:mm:ss EEE, MMM dd yyyy a X");
+    private DateTimeFormatter dfSimple = DateTimeFormatter.ofPattern("hh:mm:ss MM/dd/yyyy a X", Locale.US);
+    private DateTimeFormatter df = DateTimeFormatter.ofPattern("hh:mm:ss EEE, MMM dd yyyy a X", Locale.US);
 
     @Test
     public void testBasicCron() throws ParseException {


### PR DESCRIPTION
Fix potential null pointer exception for issue #274

Extract logic for next/previous year, month, DoM, hour, minute and second for methods `ExecutionTime.potentialNextClosestMatch()` and `ExecutionTime.potentialPreviousClosestMatch()`

Replace nested collection creation `new ArrayList<>(new HashSet<>(list)).sort()` with Stream API `list.stream().distinct().sort().collect(Collectors.tolist())`

Add locale for OpenIssuesTest, failing for some regional default locales.