### PR TITLE
Follow-up to making minor methods public. Provide access to resource bundle.

### DIFF
--- a/src/main/java/com/cronutils/descriptor/CronDescriptor.java
+++ b/src/main/java/com/cronutils/descriptor/CronDescriptor.java
@@ -175,4 +175,13 @@ public class CronDescriptor {
     public static CronDescriptor instance(final Locale locale) {
         return new CronDescriptor(locale);
     }
+
+    /**
+     * Gets the current resource bundle that is in use to allow custom reuse of text phrases.
+     *
+     * @return ResourceBundle - never null.
+     */
+    public ResourceBundle getResourceBundle() {
+        return resourceBundle;
+    }
 }

--- a/src/test/java/com/cronutils/utils/descriptor/CronDescriptorTest.java
+++ b/src/test/java/com/cronutils/utils/descriptor/CronDescriptorTest.java
@@ -13,15 +13,8 @@
 
 package com.cronutils.utils.descriptor;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.Locale;
-
-import org.junit.Before;
-import org.junit.Test;
-import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 import com.cronutils.descriptor.CronDescriptor;
 import com.cronutils.model.Cron;
@@ -37,8 +30,14 @@ import com.cronutils.model.field.expression.On;
 import com.cronutils.model.field.value.IntegerFieldValue;
 import com.cronutils.model.field.value.SpecialChar;
 import com.cronutils.model.field.value.SpecialCharFieldValue;
-
-import static org.junit.Assert.assertEquals;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
 
 public class CronDescriptorTest {
     private CronDescriptor descriptor;
@@ -183,5 +182,12 @@ public class CronDescriptorTest {
                 nullFieldConstraints));
         assertEquals(String.format("at %s:%s the nearest weekday to the %s of the month", hour, minute, dayOfMonth),
                 descriptor.describe(new Cron(mockDefinition, results)));
+    }
+
+    @Test
+    public void testGetResourceBundle() {
+        assertTrue(descriptor.getResourceBundle().containsKey("hours"));
+        assertTrue(descriptor.getResourceBundle().containsKey("minutes"));
+        assertTrue(descriptor.getResourceBundle().containsKey("seconds"));
     }
 }


### PR DESCRIPTION
Our team realized that from an i8n perspective, providing public access to internationalized text in the resource bundle is potentially helpful if for some reason you need to "build-your-own" text description.
This is thus a minor tweak to the edit in https://github.com/jmrozanec/cron-utils/pull/298.

For example, our use case is that we are using cron-utils + a time duration to describe period(s) of time, so we use describeDayOfWeek(), describeMonth(), describeDayOfMonth(), and then build our own custom version of describeHHmmss() - for this function it would be helpful to have access to the current CronDescriptor ResourceBundle to ensure i8n is standardized.