### PR TITLE
Fix string representation of On field with L

### DIFF
--- a/src/main/java/com/cronutils/model/field/expression/On.java
+++ b/src/main/java/com/cronutils/model/field/expression/On.java
@@ -81,7 +81,7 @@ public class On extends FieldExpression {
     }
 
     private String getNthStringRepresentation() {
-        return getNth().getValue() > 0 ? String.format("-%sL", getNth()) : StringUtils.EMPTY;
+        return isDefault(getNth()) ? StringUtils.EMPTY : String.format("-%s", getNth());
     }
 
     private boolean isDefault(final IntegerFieldValue fieldValue) {

--- a/src/test/java/com/cronutils/model/field/expression/OnTest.java
+++ b/src/test/java/com/cronutils/model/field/expression/OnTest.java
@@ -67,6 +67,12 @@ public class OnTest {
     }
 
     @Test
+    public void testAsStringSpecialCharLWithNth() {
+        final String expression = "L-3";
+        assertEquals(expression, new On(new IntegerFieldValue(-1), new SpecialCharFieldValue(SpecialChar.L), new IntegerFieldValue(3)).asString());
+    }
+
+    @Test
     public void testAsStringWithNth() {
         final int first = 3;
         final int second = 4;


### PR DESCRIPTION
Previously, the expression `L-3` would be serialized as `L-3L`