### PR TITLE
Fixing unit tests

### DIFF
--- a/src/test/java/com/cronutils/model/time/ExecutionTimeCron4jIntegrationTest.java
+++ b/src/test/java/com/cronutils/model/time/ExecutionTimeCron4jIntegrationTest.java
@@ -46,7 +46,7 @@ public class ExecutionTimeCron4jIntegrationTest {
 
     @Test
     public void testForCron() {
-        assertEquals(ExecutionTime.class, ExecutionTime.forCron(cron4jCronParser.parse(EVERY_MONDAY_AT_18)).getClass());
+        assertEquals(SingleExecutionTime.class, ExecutionTime.forCron(cron4jCronParser.parse(EVERY_MONDAY_AT_18)).getClass());
     }
 
     /**

--- a/src/test/java/com/cronutils/model/time/ExecutionTimeQuartzIntegrationTest.java
+++ b/src/test/java/com/cronutils/model/time/ExecutionTimeQuartzIntegrationTest.java
@@ -65,7 +65,7 @@ public class ExecutionTimeQuartzIntegrationTest {
 
     @Test
     public void testForCron() {
-        assertEquals(ExecutionTime.class, ExecutionTime.forCron(parser.parse(EVERY_SECOND)).getClass());
+        assertEquals(SingleExecutionTime.class, ExecutionTime.forCron(parser.parse(EVERY_SECOND)).getClass());
     }
 
     @Test

--- a/src/test/java/com/cronutils/model/time/ExecutionTimeQuartzWithDayOfYearExtensionIntegrationTest.java
+++ b/src/test/java/com/cronutils/model/time/ExecutionTimeQuartzWithDayOfYearExtensionIntegrationTest.java
@@ -48,10 +48,10 @@ public class ExecutionTimeQuartzWithDayOfYearExtensionIntegrationTest {
 
     @Test
     public void testForCron() {
-        assertEquals(ExecutionTime.class, ExecutionTime.forCron(parser.parse(BI_WEEKLY_STARTING_WITH_FIRST_DAY_OF_YEAR)).getClass());
-        assertEquals(ExecutionTime.class, ExecutionTime.forCron(parser.parse(FIRST_QUARTER_BI_WEEKLY_STARTING_WITH_FIRST_DAY_OF_YEAR)).getClass());
-        assertEquals(ExecutionTime.class, ExecutionTime.forCron(parser.parse(WITHOUT_DAY_OF_YEAR)).getClass());
-        assertEquals(ExecutionTime.class, ExecutionTime.forCron(parser.parse(WITHOUT_SPECIFIC_DAY_OF_YEAR)).getClass());
+        assertEquals(SingleExecutionTime.class, ExecutionTime.forCron(parser.parse(BI_WEEKLY_STARTING_WITH_FIRST_DAY_OF_YEAR)).getClass());
+        assertEquals(SingleExecutionTime.class, ExecutionTime.forCron(parser.parse(FIRST_QUARTER_BI_WEEKLY_STARTING_WITH_FIRST_DAY_OF_YEAR)).getClass());
+        assertEquals(SingleExecutionTime.class, ExecutionTime.forCron(parser.parse(WITHOUT_DAY_OF_YEAR)).getClass());
+        assertEquals(SingleExecutionTime.class, ExecutionTime.forCron(parser.parse(WITHOUT_SPECIFIC_DAY_OF_YEAR)).getClass());
     }
 
     @Test //issue #249


### PR DESCRIPTION
Fixing unit tests to expect SingleExecutionTime.class instead of ExecutionTime.class.