### PR TITLE
Add optional jsr 303 validator.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -76,6 +76,12 @@
             <artifactId>slf4j-api</artifactId>
             <version>${slf4j.version}</version>
         </dependency>
+        <dependency>
+            <groupId>javax.validation</groupId>
+            <artifactId>validation-api</artifactId>
+            <version>1.1.0.Final</version>
+            <scope>provided</scope>
+        </dependency>
 
         <!--test dependencies-->
         <dependency>
@@ -106,6 +112,18 @@
             <groupId>org.quartz-scheduler</groupId>
             <artifactId>quartz</artifactId>
             <version>2.2.3</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hibernate</groupId>
+            <artifactId>hibernate-validator</artifactId>
+            <version>5.2.4.Final</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>javax.el</groupId>
+            <artifactId>javax.el-api</artifactId>
+            <version>2.2.5</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/src/main/java/com/cronutils/validation/Cron.java
+++ b/src/main/java/com/cronutils/validation/Cron.java
@@ -1,0 +1,24 @@
+package com.cronutils.validation;
+
+import com.cronutils.model.CronType;
+
+import javax.validation.Constraint;
+import javax.validation.Payload;
+import java.lang.annotation.*;
+
+@Target({ElementType.FIELD, ElementType.ANNOTATION_TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Constraint(validatedBy = CronValidator.class)
+@Inherited
+@Documented
+public @interface Cron {
+
+    String message() default "UNUSED";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+
+    CronType type() default CronType.SPRING;
+
+}

--- a/src/main/java/com/cronutils/validation/Cron.java
+++ b/src/main/java/com/cronutils/validation/Cron.java
@@ -19,6 +19,6 @@ public @interface Cron {
 
     Class<? extends Payload>[] payload() default {};
 
-    CronType type() default CronType.SPRING;
+    CronType type();
 
 }

--- a/src/main/java/com/cronutils/validation/CronValidator.java
+++ b/src/main/java/com/cronutils/validation/CronValidator.java
@@ -1,0 +1,37 @@
+package com.cronutils.validation;
+
+import com.cronutils.model.CronType;
+import com.cronutils.model.definition.CronDefinition;
+import com.cronutils.model.definition.CronDefinitionBuilder;
+import com.cronutils.parser.CronParser;
+
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+
+public class CronValidator implements ConstraintValidator<Cron, String> {
+
+    private CronType type;
+
+    @Override
+    public void initialize(Cron constraintAnnotation) {
+        this.type = constraintAnnotation.type();
+    }
+
+    @Override
+    public boolean isValid(String value, ConstraintValidatorContext context) {
+        if (value == null) {
+            return true;
+        }
+
+        CronDefinition cronDefinition = CronDefinitionBuilder.instanceDefinitionFor(type);
+        CronParser cronParser = new CronParser(cronDefinition);
+        try {
+            cronParser.parse(value).validate();
+            return true;
+        } catch (IllegalArgumentException e) {
+            context.disableDefaultConstraintViolation();
+            context.buildConstraintViolationWithTemplate(e.getMessage()).addConstraintViolation();
+            return false;
+        }
+    }
+}

--- a/src/test/java/com/cronutils/validation/CronValidatorTest.java
+++ b/src/test/java/com/cronutils/validation/CronValidatorTest.java
@@ -1,0 +1,68 @@
+package com.cronutils.validation;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import javax.validation.ConstraintViolation;
+import javax.validation.Validation;
+import javax.validation.Validator;
+
+import java.util.Set;
+
+import static org.junit.Assert.*;
+
+@RunWith(Parameterized.class)
+public class CronValidatorTest {
+
+    private final Validator validator = Validation.buildDefaultValidatorFactory().getValidator();
+
+    private final String expression;
+    private final boolean valid;
+
+    public CronValidatorTest(String expression, boolean valid) {
+        this.expression = expression;
+        this.valid = valid;
+    }
+
+    @Parameterized.Parameters(name = "{0} ")
+    public static Object[] expressions() {
+        // List of expressions from https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/scheduling/support/CronSequenceGenerator.html
+        return new Object[][]{
+                {"0 0 * * * *", true},
+                {"*/10 * * * * *", true},
+                {"0 0 8-10 * * *", true},
+                {"0 0 6,19 * * *", true},
+                {"0 0/30 8-10 * * *", true},
+                {"0 0 9-17 * * MON-FRI", true},
+                {"0 0 0 25 12 ?", true},
+                {"1, * * * * *", false}
+        };
+    }
+
+    @Test
+    public void validateExamples() {
+        TestPojo testPojo = new TestPojo(expression);
+        Set<ConstraintViolation<TestPojo>> violations = validator.validate(testPojo);
+
+        if (valid) {
+            assertTrue(violations.isEmpty());
+        } else {
+            assertFalse(violations.isEmpty());
+        }
+    }
+
+    public static class TestPojo {
+        @Cron
+        private final String cron;
+
+        public TestPojo(String cron) {
+            this.cron = cron;
+        }
+
+        public String getCron() {
+            return cron;
+        }
+
+    }
+}

--- a/src/test/java/com/cronutils/validation/CronValidatorTest.java
+++ b/src/test/java/com/cronutils/validation/CronValidatorTest.java
@@ -1,5 +1,6 @@
 package com.cronutils.validation;
 
+import com.cronutils.model.CronType;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -27,7 +28,6 @@ public class CronValidatorTest {
 
     @Parameterized.Parameters(name = "{0} ")
     public static Object[] expressions() {
-        // List of expressions from https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/scheduling/support/CronSequenceGenerator.html
         return new Object[][]{
                 {"0 0 * * * *", true},
                 {"*/10 * * * * *", true},
@@ -36,7 +36,9 @@ public class CronValidatorTest {
                 {"0 0/30 8-10 * * *", true},
                 {"0 0 9-17 * * MON-FRI", true},
                 {"0 0 0 25 12 ?", true},
-                {"1, * * * * *", false}
+                {"0 0 0 L 12 ?", false},
+                {"1,2, * * * * *", false},
+                {"1- * * * * *", false}
         };
     }
 
@@ -53,7 +55,7 @@ public class CronValidatorTest {
     }
 
     public static class TestPojo {
-        @Cron
+        @Cron(type = CronType.SPRING)
         private final String cron;
 
         public TestPojo(String cron) {


### PR DESCRIPTION
If you want to use it in your project, you'll have to provide the
javax.validation validation-api library on the classpath.

Only supports the definitions provided by CronDefinitionBuilder.instanceDefinitionFor(CronType).