### PR TITLE
Quartz cron expressions should allow overflowing ranges

### DIFF
--- a/src/main/java/com/cronutils/model/definition/CronDefinitionBuilder.java
+++ b/src/main/java/com/cronutils/model/definition/CronDefinitionBuilder.java
@@ -258,10 +258,10 @@ public class CronDefinitionBuilder {
      */
     private static CronDefinition quartz() {
         return CronDefinitionBuilder.defineCron()
-                .withSeconds().withStrictRange().and()
-                .withMinutes().withStrictRange().and()
-                .withHours().withStrictRange().and()
-                .withDayOfMonth().withValidRange(1, 32).supportsL().supportsW().supportsLW().supportsQuestionMark().withStrictRange().and()
+                .withSeconds().and()
+                .withMinutes().and()
+                .withHours().and()
+                .withDayOfMonth().withValidRange(1, 32).supportsL().supportsW().supportsLW().supportsQuestionMark().and()
                 .withMonth().withValidRange(1, 13).and()
                 .withDayOfWeek().withValidRange(1, 7).withMondayDoWValue(2).supportsHash().supportsL().supportsQuestionMark().and()
                 .withYear().withValidRange(1970, 2099).withStrictRange().optional().and()

--- a/src/test/java/com/cronutils/validator/CronValidatorQuartzIntegrationTest.java
+++ b/src/test/java/com/cronutils/validator/CronValidatorQuartzIntegrationTest.java
@@ -85,4 +85,19 @@ public class CronValidatorQuartzIntegrationTest {
         parser.parse("0 0 12 ? * FRI-SAT");
         parser.parse("0 0 12 ? * SAT-SUN");
     }
+
+    /**
+     * Issue #396: overflow ranges
+     * Quartz cron expressions should support overflowing ranges
+     * See https://github.com/quartz-scheduler/quartz/blob/master/quartz-core/src/main/java/org/quartz/CronExpression.java
+     */
+    @Test
+    public void testOverflowRange() {
+        parser.parse("20-10 0 0 ? * 3"); // second overflow
+        parser.parse("0 40-20 0 ? * 3"); // minute overflow
+        parser.parse("0 0 12-2 ? * 3"); // hour overflow
+        parser.parse("0 0 0 24-7 * ?"); // day of month overflow
+        parser.parse("0 0 0 ? 10-3 3"); // month overflow
+        parser.parse("0 0 0 ? * 5-1"); // day of week overflow
+    }
 }


### PR DESCRIPTION
Quartz cron expressions should allow overflowing ranges.

Fixes #396 