### PR TITLE
Check for case where hash is the last value of cron expression #412

### DIFF
--- a/src/main/java/com/cronutils/parser/CronParser.java
+++ b/src/main/java/com/cronutils/parser/CronParser.java
@@ -121,7 +121,8 @@ public class CronParser {
                         String.format("Cron expression contains %s parts but we expect one of %s", expressionLength, expressions.keySet()));
             }
             try {
-                final int size = fields.size();
+
+                final int size = expressionParts.length;
                 final List<CronField> results = new ArrayList<>(size + 1);
                 for (int j = 0; j < size; j++) {
                     results.add(fields.get(j).parse(expressionParts[j]));
@@ -133,3 +134,4 @@ public class CronParser {
         }
     }
 }
+

--- a/src/main/java/com/cronutils/parser/FieldParser.java
+++ b/src/main/java/com/cronutils/parser/FieldParser.java
@@ -182,6 +182,9 @@ public class FieldParser {
         }
         final SpecialCharFieldValue specialChar = new SpecialCharFieldValue(HASH);
         final String[] array = exp.split(HASH_TAG);
+        if (array.length == 0) {
+            throw new IllegalArgumentException("Invalid Position of # Character!");
+        }
         final IntegerFieldValue nth = mapToIntegerFieldValue(array[1]);
         if (array[0].isEmpty()) {
             throw new IllegalArgumentException("Time should be specified!");

--- a/src/test/java/com/cronutils/parser/CronParserTest.java
+++ b/src/test/java/com/cronutils/parser/CronParserTest.java
@@ -101,6 +101,11 @@ public class CronParserTest {
         validateExpression(CronType.UNIX, "1, * * * *");
     }
 
+    @Test(expected = IllegalArgumentException.class)
+    public void testHashListUnix(){
+        validateExpression(CronType.UNIX, "0 0 0 ? * #");
+    }
+
     @Test // issue #369
     public void testParseIncompleteRangeNoValues() {
         parseIncompleteExpression("-", "Missing values for range: -");
@@ -216,5 +221,11 @@ public class CronParserTest {
         parser = new CronParser(CronDefinitionBuilder.instanceDefinitionFor(CronType.QUARTZ));
         Cron cron = parser.parse(multicron);
         assertEquals(multicron, cron.asString());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testParseQuartzCronWithHash() {
+        parser = new CronParser(TestCronDefinitionsFactory.withDayOfYearDefinitionWhereYearAndDoYOptionals());
+        parser.parse("0 0 0 ? * #");
     }
 }


### PR DESCRIPTION
This fixes issue #412 

The issue was on line 184 of the cronparser. In this case, the hash was the only value, so when the split method gets called, it returns an empty list. 

Please note the build was failing prior to this pull request due to other issues and have I not fixed it for this bug fix. 