### PR TITLE
Change Lombok dependency scope

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -149,6 +149,7 @@
 			<groupId>org.projectlombok</groupId>
 			<artifactId>lombok</artifactId>
 			<version>1.18.10</version>
+			<scope>provided</scope>
 		</dependency>
     </dependencies>
 


### PR DESCRIPTION
Use the recommended Lombok scope: https://projectlombok.org/setup/maven to avoid including it in the library clients' classpath/distribution. Closes #437 .