### PR TITLE
Fix every description and fix #421

### DIFF
--- a/src/main/java/com/cronutils/descriptor/DescriptionStrategyFactory.java
+++ b/src/main/java/com/cronutils/descriptor/DescriptionStrategyFactory.java
@@ -13,6 +13,7 @@
 
 package com.cronutils.descriptor;
 
+import com.cronutils.model.field.expression.Every;
 import java.time.DayOfWeek;
 import java.time.Month;
 import java.time.format.TextStyle;
@@ -102,7 +103,13 @@ class DescriptionStrategyFactory {
      * @return - DescriptionStrategy instance, never null
      */
     public static DescriptionStrategy monthsInstance(final ResourceBundle bundle, final FieldExpression expression) {
-        return new NominalDescriptionStrategy(bundle, integer -> Month.of(integer).getDisplayName(TextStyle.FULL, bundle.getLocale()), expression);
+        Function<Integer, String> mappingFunction;
+        if (expression instanceof Every) {
+            mappingFunction = Object::toString;
+        } else {
+            mappingFunction = integer -> Month.of(integer).getDisplayName(TextStyle.FULL, bundle.getLocale());
+        }
+        return new NominalDescriptionStrategy(bundle, mappingFunction, expression);
     }
 
     /**

--- a/src/main/java/com/cronutils/model/field/expression/Every.java
+++ b/src/main/java/com/cronutils/model/field/expression/Every.java
@@ -18,7 +18,9 @@ import com.cronutils.utils.Preconditions;
 
 /**
  * Represents every x time on a cron field.
- */
+ * Usage examples:
+ * - To represent a scheduling every 3 months on a specific time (the standard 0 0 0 *&#47;3 *), use the Every(3) constructor
+ * - To represent a scheduling every 3 months FROM NOW, use the Every(on(now.getMonth, 3)) constructor */
 public class Every extends FieldExpression {
 
     private static final long serialVersionUID = -1103196842332906994L;

--- a/src/test/java/Issue421Test.java
+++ b/src/test/java/Issue421Test.java
@@ -32,29 +32,54 @@ public class Issue421Test {
             .withCronValidation(CronConstraintsFactory.ensureEitherDayOfYearOrMonth())
             .instance();
 
-    @Ignore
     @Test
-    public void testWrongIntervalsForEvery6Months() {
-        LocalDateTime firstOfJanuary = LocalDateTime.of(2020, 4, 25, 0, 0);
+    public void testIntervals_Every5thMonths_SinceASpecificMonth() {
+        LocalDateTime firstOfJanuary = LocalDateTime.of(2020, 2, 10, 0, 0);
         Clock clock = Clock.fixed(firstOfJanuary.toInstant(ZoneOffset.UTC), ZoneId.systemDefault());
         ZonedDateTime now = ZonedDateTime.now(clock);
         System.out.println("now: " + now);
 
-        Cron cron = getEveryMonth(now, 6).instance();
+        Cron cron = getEveryMonthFromNow(now, 5).instance();
         ZonedDateTime nextRun;
 
         nextRun = nextRun(cron, now); // first run
         Assert.assertEquals(2020, nextRun.getYear());
-        Assert.assertEquals(10, nextRun.getMonthValue());
+        Assert.assertEquals(7, nextRun.getMonthValue());
 
-        nextRun = nextRun(cron, nextRun); // second
+        nextRun = nextRun(cron, nextRun); // first run
+        Assert.assertEquals(2020, nextRun.getYear());
+        Assert.assertEquals(12, nextRun.getMonthValue());
+
+        nextRun = nextRun(cron, nextRun); // first run
         Assert.assertEquals(2021, nextRun.getYear());
-        Assert.assertEquals(4, nextRun.getMonthValue());
+        Assert.assertEquals(2, nextRun.getMonthValue());
     }
 
-    @Ignore
     @Test
-    public void testWrongEveryXMonthsDescription() {
+    public void testIntervals_Every5thMonth() {
+        LocalDateTime firstOfJanuary = LocalDateTime.of(2020, 2, 10, 0, 0);
+        Clock clock = Clock.fixed(firstOfJanuary.toInstant(ZoneOffset.UTC), ZoneId.systemDefault());
+        ZonedDateTime now = ZonedDateTime.now(clock);
+        System.out.println("now: " + now);
+
+        Cron cron = getEveryMonth(now, 5).instance();
+        ZonedDateTime nextRun;
+
+        nextRun = nextRun(cron, now); // first run
+        Assert.assertEquals(2020, nextRun.getYear());
+        Assert.assertEquals(6, nextRun.getMonthValue());
+
+        nextRun = nextRun(cron, nextRun); // first run
+        Assert.assertEquals(2020, nextRun.getYear());
+        Assert.assertEquals(11, nextRun.getMonthValue());
+
+        nextRun = nextRun(cron, nextRun); // first run
+        Assert.assertEquals(2021, nextRun.getYear());
+        Assert.assertEquals(1, nextRun.getMonthValue());
+    }
+
+    @Test
+    public void testDescription_EveryXMonths() {
         ZonedDateTime now = ZonedDateTime.now();
 
         String description = CronDescriptor.instance(Locale.US).describe(getEveryMonth(now, 3).instance());
@@ -74,6 +99,15 @@ public class Issue421Test {
                 .withDoM(on(now.getDayOfMonth()))
                 .withDoY(questionMark())
                 .withMonth(every(every));
+    }
+    public static CronBuilder getEveryMonthFromNow(ZonedDateTime now, int every) {
+        return CronBuilder.cron(definition)
+                .withMinute(on(now.getMinute()))
+                .withHour(on(now.getHour()))
+                .withDoW(questionMark())
+                .withDoM(on(now.getDayOfMonth()))
+                .withDoY(questionMark())
+                .withMonth(every(on(now.getMonthValue()),every));
     }
 
     private static ZonedDateTime nextRun(Cron cron, ZonedDateTime when) {


### PR DESCRIPTION
With this PR I'm aiming to solve issue #421 .

I checked the test and it seems that the library is behaving as expected, following cron style: "every(6)" should not be intended as "every 6 months", but "on every 6th month", meaning on January and July.
The library also allows to compute "every 6h month" starting from a date, if you use the "every(on(_date_), 6)" method.

For this reason, I added some javadoc on the "Every" class, to explain its usage, and added additional tests in the test class created for issue #421. 

I did my best to make the explanation clear but I really appreciate feedbacks.