### PR TITLE
Rework FieldExpressionVisitor so that subtypes invoke the correct method.

### DIFF
--- a/src/main/java/com/cronutils/descriptor/refactor/SecondsDescriptor.java
+++ b/src/main/java/com/cronutils/descriptor/refactor/SecondsDescriptor.java
@@ -172,11 +172,6 @@ class SecondsDescriptor implements FieldExpressionVisitor {
     }
 
     @Override
-    public FieldExpression visit(final FieldExpression expression) {
-        return null;
-    }
-
-    @Override
     public Always visit(final Always always) {
         return null;
     }

--- a/src/main/java/com/cronutils/model/field/expression/Always.java
+++ b/src/main/java/com/cronutils/model/field/expression/Always.java
@@ -14,6 +14,8 @@
 
 package com.cronutils.model.field.expression;
 
+import com.cronutils.model.field.expression.visitor.FieldExpressionVisitor;
+
 /**
  * Represents a star (*) value on cron expression field.
  */
@@ -27,6 +29,11 @@ public class Always extends FieldExpression {
      * Class should become package private too.
      */
     private Always() {
+    }
+
+    @Override
+    public FieldExpression accept(FieldExpressionVisitor visitor) {
+        return visitor.visit(this);
     }
 
     @Override

--- a/src/main/java/com/cronutils/model/field/expression/And.java
+++ b/src/main/java/com/cronutils/model/field/expression/And.java
@@ -14,6 +14,8 @@
 
 package com.cronutils.model.field.expression;
 
+import com.cronutils.model.field.expression.visitor.FieldExpressionVisitor;
+
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -34,6 +36,11 @@ public class And extends FieldExpression {
     public And and(final FieldExpression exp) {
         expressions.add(exp);
         return this;
+    }
+
+    @Override
+    public FieldExpression accept(FieldExpressionVisitor visitor) {
+        return visitor.visit(this);
     }
 
     @Override

--- a/src/main/java/com/cronutils/model/field/expression/Between.java
+++ b/src/main/java/com/cronutils/model/field/expression/Between.java
@@ -2,6 +2,7 @@
 
 package com.cronutils.model.field.expression;
 
+import com.cronutils.model.field.expression.visitor.FieldExpressionVisitor;
 import com.cronutils.model.field.value.FieldValue;
 
 /**
@@ -28,6 +29,11 @@ public class Between extends FieldExpression {
 
     public FieldValue<?> getTo() {
         return to;
+    }
+
+    @Override
+    public FieldExpression accept(FieldExpressionVisitor visitor) {
+        return visitor.visit(this);
     }
 
     @Override

--- a/src/main/java/com/cronutils/model/field/expression/Every.java
+++ b/src/main/java/com/cronutils/model/field/expression/Every.java
@@ -13,6 +13,7 @@
 
 package com.cronutils.model.field.expression;
 
+import com.cronutils.model.field.expression.visitor.FieldExpressionVisitor;
 import com.cronutils.model.field.value.IntegerFieldValue;
 import com.cronutils.utils.Preconditions;
 
@@ -42,6 +43,11 @@ public class Every extends FieldExpression {
 
     public FieldExpression getExpression() {
         return expression;
+    }
+
+    @Override
+    public FieldExpression accept(FieldExpressionVisitor visitor) {
+        return visitor.visit(this);
     }
 
     @Override

--- a/src/main/java/com/cronutils/model/field/expression/FieldExpression.java
+++ b/src/main/java/com/cronutils/model/field/expression/FieldExpression.java
@@ -41,10 +41,7 @@ public abstract class FieldExpression implements Serializable {
      * @param visitor - FieldExpressionVisitor instance, never null
      * @return FieldExpression copied instance with visitor action performed.
      */
-    public final FieldExpression accept(final FieldExpressionVisitor visitor) {
-        Preconditions.checkNotNull(visitor, "FieldExpressionVisitor must not be null");
-        return visitor.visit(this);
-    }
+    public abstract FieldExpression accept(final FieldExpressionVisitor visitor);
 
     public static FieldExpression always() {
         return Always.INSTANCE;

--- a/src/main/java/com/cronutils/model/field/expression/On.java
+++ b/src/main/java/com/cronutils/model/field/expression/On.java
@@ -13,6 +13,7 @@
 
 package com.cronutils.model.field.expression;
 
+import com.cronutils.model.field.expression.visitor.FieldExpressionVisitor;
 import com.cronutils.model.field.value.IntegerFieldValue;
 import com.cronutils.model.field.value.SpecialChar;
 import com.cronutils.model.field.value.SpecialCharFieldValue;
@@ -62,6 +63,11 @@ public class On extends FieldExpression {
 
     public SpecialCharFieldValue getSpecialChar() {
         return specialChar;
+    }
+
+    @Override
+    public FieldExpression accept(FieldExpressionVisitor visitor) {
+        return visitor.visit(this);
     }
 
     @Override

--- a/src/main/java/com/cronutils/model/field/expression/QuestionMark.java
+++ b/src/main/java/com/cronutils/model/field/expression/QuestionMark.java
@@ -13,6 +13,8 @@
 
 package com.cronutils.model.field.expression;
 
+import com.cronutils.model.field.expression.visitor.FieldExpressionVisitor;
+
 /**
  * Represents a question mark (?) value on cron expression field.
  */
@@ -25,6 +27,11 @@ public final class QuestionMark extends FieldExpression {
      * Should be package private and not be instantiated elsewhere. Class should become package private too.
      */
     private QuestionMark() {
+    }
+
+    @Override
+    public FieldExpression accept(FieldExpressionVisitor visitor) {
+        return visitor.visit(this);
     }
 
     @Override

--- a/src/main/java/com/cronutils/model/field/expression/visitor/FieldExpressionVisitor.java
+++ b/src/main/java/com/cronutils/model/field/expression/visitor/FieldExpressionVisitor.java
@@ -17,18 +17,14 @@ import com.cronutils.model.field.expression.*;
 
 /**
  * Visitor for custom actions performed on FieldExpression instances.
+ *
+ * <p>
+ * If a method needs to modify some value, it should return a new instance.
+ * This way we ensure immutability is preserved.
+ *
+ * @see FieldExpressionVisitorAdaptor
  */
 public interface FieldExpressionVisitor {
-    /**
-     * Performs an action using given FieldExpression instance.
-     * If requires to modify some value,
-     * should return a new instance with those values.
-     * This way we ensure immutability is preserved.
-     *
-     * @param expression - FieldExpression, never null
-     * @return FieldExpression instance, never null
-     */
-    FieldExpression visit(FieldExpression expression);
 
     /**
      * Performs action on Always instance.

--- a/src/main/java/com/cronutils/model/field/expression/visitor/FieldExpressionVisitorAdaptor.java
+++ b/src/main/java/com/cronutils/model/field/expression/visitor/FieldExpressionVisitorAdaptor.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2015 jmrozanec
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.cronutils.model.field.expression.visitor;
+
+import com.cronutils.model.field.expression.*;
+
+/**
+ * Adaptor calss for the {@link FieldExpressionVisitor} interface.
+ */
+public class FieldExpressionVisitorAdaptor implements FieldExpressionVisitor {
+
+    @Override
+    public FieldExpression visit(Always always) {
+        return this.caseDefault(always);
+    }
+
+    @Override
+    public FieldExpression visit(And and) {
+        return this.caseDefault(and);
+    }
+
+    @Override
+    public FieldExpression visit(Between between) {
+        return this.caseDefault(between);
+    }
+
+    @Override
+    public FieldExpression visit(Every every) {
+        return this.caseDefault(every);
+    }
+
+    @Override
+    public FieldExpression visit(On on) {
+        return this.caseDefault(on);
+    }
+
+    @Override
+    public FieldExpression visit(QuestionMark questionMark) {
+        return this.caseDefault(questionMark);
+    }
+
+    /**
+     * Internal roll-up method.
+     *
+     * <p>
+     * The implementation in {@link FieldExpressionVisitorAdaptor} returns its argument.
+     */
+    protected <T extends FieldExpression> T caseDefault(T expression) {
+        return expression;
+    }
+}
+

--- a/src/main/java/com/cronutils/model/field/expression/visitor/ValidationFieldExpressionVisitor.java
+++ b/src/main/java/com/cronutils/model/field/expression/visitor/ValidationFieldExpressionVisitor.java
@@ -24,7 +24,6 @@ import com.cronutils.utils.VisibleForTesting;
 
 public class ValidationFieldExpressionVisitor implements FieldExpressionVisitor {
     private static final String OORANGE = "Value %s not in range [%s, %s]";
-    private static final String EMPTY_STRING = "";
 
     private final FieldConstraints constraints;
     private final StringValidations stringValidations;
@@ -39,29 +38,10 @@ public class ValidationFieldExpressionVisitor implements FieldExpressionVisitor 
         stringValidations = stringValidation;
     }
 
-    @Override
-    public FieldExpression visit(final FieldExpression expression) {
+    private void checkUnsupportedChars(final FieldExpression expression) {
         final String unsupportedChars = stringValidations.removeValidChars(expression.asString());
-        if (EMPTY_STRING.equals(unsupportedChars)) {
-            if (expression instanceof Always) {
-                return visit((Always) expression);
-            }
-            if (expression instanceof And) {
-                return visit((And) expression);
-            }
-            if (expression instanceof Between) {
-                return visit((Between) expression);
-            }
-            if (expression instanceof Every) {
-                return visit((Every) expression);
-            }
-            if (expression instanceof On) {
-                return visit((On) expression);
-            }
-            if (expression instanceof QuestionMark) {
-                return visit((QuestionMark) expression);
-            }
-        }
+        if (unsupportedChars.isEmpty())
+            return;
         throw new IllegalArgumentException(
                 String.format("Invalid chars in expression! Expression: %s Invalid chars: %s",
                         expression.asString(), unsupportedChars)
@@ -70,19 +50,22 @@ public class ValidationFieldExpressionVisitor implements FieldExpressionVisitor 
 
     @Override
     public Always visit(final Always always) {
+        this.checkUnsupportedChars(always);
         return always;
     }
 
     @Override
     public And visit(final And and) {
+        this.checkUnsupportedChars(and);
         for (final FieldExpression expression : and.getExpressions()) {
-            visit(expression);
+            expression.accept(this);
         }
         return and;
     }
 
     @Override
     public Between visit(final Between between) {
+        this.checkUnsupportedChars(between);
         preConditions(between);
 
         if ((constraints.isStrictRange()) && between.getFrom() instanceof IntegerFieldValue && between.getTo() instanceof IntegerFieldValue) {
@@ -98,18 +81,16 @@ public class ValidationFieldExpressionVisitor implements FieldExpressionVisitor 
 
     @Override
     public Every visit(final Every every) {
-        if (every.getExpression() instanceof Between) {
-            visit((Between) every.getExpression());
-        }
-        if (every.getExpression() instanceof On) {
-            visit((On) every.getExpression());
-        }
+        this.checkUnsupportedChars(every);
+        if (every.getExpression() != null)
+            every.getExpression().accept(this);
         isPeriodInRange(every.getPeriod());
         return every;
     }
 
     @Override
     public On visit(final On on) {
+        this.checkUnsupportedChars(on);
         if (!isDefault(on.getTime())) {
             isInRange(on.getTime());
         }
@@ -121,6 +102,7 @@ public class ValidationFieldExpressionVisitor implements FieldExpressionVisitor 
 
     @Override
     public QuestionMark visit(final QuestionMark questionMark) {
+        this.checkUnsupportedChars(questionMark);
         return questionMark;
     }
 

--- a/src/main/java/com/cronutils/model/field/expression/visitor/ValueMappingFieldExpressionVisitor.java
+++ b/src/main/java/com/cronutils/model/field/expression/visitor/ValueMappingFieldExpressionVisitor.java
@@ -41,7 +41,7 @@ public class ValueMappingFieldExpressionVisitor implements FieldExpressionVisito
     public FieldExpression visit(final And and) {
         final And clone = new And();
         for (final FieldExpression expression : and.getExpressions()) {
-            clone.and(visit(expression));
+            clone.and(expression.accept(this));
         }
         return clone;
     }
@@ -66,29 +66,6 @@ public class ValueMappingFieldExpressionVisitor implements FieldExpressionVisito
     @Override
     public FieldExpression visit(final QuestionMark questionMark) {
         return questionMark();
-    }
-
-    @Override
-    public FieldExpression visit(final FieldExpression expression) {
-        if (expression instanceof Always) {
-            return visit((Always) expression);
-        }
-        if (expression instanceof And) {
-            return visit((And) expression);
-        }
-        if (expression instanceof Between) {
-            return visit((Between) expression);
-        }
-        if (expression instanceof Every) {
-            return visit((Every) expression);
-        }
-        if (expression instanceof On) {
-            return visit((On) expression);
-        }
-        if (expression instanceof QuestionMark) {
-            return visit((QuestionMark) expression);
-        }
-        return expression;
     }
 }
 

--- a/src/test/java/com/cronutils/model/field/expression/FieldExpressionTest.java
+++ b/src/test/java/com/cronutils/model/field/expression/FieldExpressionTest.java
@@ -13,6 +13,8 @@
 
 package com.cronutils.model.field.expression;
 
+import com.cronutils.model.field.expression.visitor.*;
+
 import org.junit.Before;
 import org.junit.Test;
 
@@ -38,6 +40,11 @@ public class FieldExpressionTest {
     class TestFieldExpression extends FieldExpression {
 
         private static final long serialVersionUID = 8101930390397976027L;
+
+        @Override
+        public FieldExpression accept(final FieldExpressionVisitor visitor) {
+            return null;
+        }
 
         @Override
         public String asString() {

--- a/src/test/java/com/cronutils/model/field/expression/visitor/ValidationFieldExpressionVisitorTest.java
+++ b/src/test/java/com/cronutils/model/field/expression/visitor/ValidationFieldExpressionVisitorTest.java
@@ -59,7 +59,7 @@ public class ValidationFieldExpressionVisitorTest {
     public void testVisitWithInvalidChars() {
         final ValidationFieldExpressionVisitor tempVisitor = new ValidationFieldExpressionVisitor(fieldConstraints, invalidStringValidations);
         final FieldExpression exp = FieldExpression.always();
-        tempVisitor.visit(exp);
+        exp.accept(tempVisitor);
     }
 
     @Test
@@ -69,156 +69,156 @@ public class ValidationFieldExpressionVisitorTest {
 
         FieldExpression exp = FieldExpression.always();
         final Always always = (Always) exp;
-        spy.visit(exp);
-        strictSpy.visit(exp);
+        exp.accept(spy);
+        exp.accept(strictSpy);
 
-        verify(spy, times(1)).visit(always);
-        verify(strictSpy, times(1)).visit(always);
+        always.accept(verify(spy, times(1)));
+        always.accept(verify(strictSpy, times(1)));
 
         spy = Mockito.spy(visitor);
         strictSpy = Mockito.spy(strictVisitor);
 
         exp = new Between(new IntegerFieldValue(LOW), new IntegerFieldValue(MIDDLE));
         final Between between = (Between) exp;
-        spy.visit(exp);
-        strictSpy.visit(exp);
+        exp.accept(spy);
+        exp.accept(strictSpy);
 
-        verify(spy, times(1)).visit(between);
-        verify(strictSpy, times(1)).visit(between);
+        between.accept(verify(spy, times(1)));
+        between.accept(verify(strictSpy, times(1)));
 
         spy = Mockito.spy(visitor);
         strictSpy = Mockito.spy(strictVisitor);
 
         exp = new Every(new IntegerFieldValue(LOW));
         final Every every = (Every) exp;
-        spy.visit(exp);
-        strictSpy.visit(exp);
+        exp.accept(spy);
+        exp.accept(strictSpy);
 
-        verify(spy, times(1)).visit(every);
-        verify(strictSpy, times(1)).visit(every);
+        every.accept(verify(spy, times(1)));
+        every.accept(verify(strictSpy, times(1)));
 
         spy = Mockito.spy(visitor);
         strictSpy = Mockito.spy(strictVisitor);
 
         exp = new And().and(between);
         final And and = (And) exp;
-        spy.visit(exp);
-        strictSpy.visit(exp);
+        exp.accept(spy);
+        exp.accept(strictSpy);
 
-        verify(spy, times(1)).visit(and);
-        verify(strictSpy, times(1)).visit(and);
-        verify(spy, times(1)).visit(between);
-        verify(strictSpy, times(1)).visit(between);
+        and.accept(verify(spy, times(1)));
+        and.accept(verify(strictSpy, times(1)));
+        between.accept(verify(spy, times(1)));
+        between.accept(verify(strictSpy, times(1)));
 
         spy = Mockito.spy(visitor);
         strictSpy = Mockito.spy(strictVisitor);
 
         exp = new On(new IntegerFieldValue(MIDDLE));
         final On on = (On) exp;
-        spy.visit(exp);
-        strictSpy.visit(exp);
+        exp.accept(spy);
+        exp.accept(strictSpy);
 
-        verify(spy, times(1)).visit(on);
-        verify(strictSpy, times(1)).visit(on);
+        on.accept(verify(spy, times(1)));
+        on.accept(verify(strictSpy, times(1)));
 
         spy = Mockito.spy(visitor);
         strictSpy = Mockito.spy(strictVisitor);
 
         exp = FieldExpression.questionMark();
         final QuestionMark qm = (QuestionMark) exp;
-        spy.visit(exp);
-        strictSpy.visit(exp);
+        exp.accept(spy);
+        exp.accept(strictSpy);
 
-        verify(spy, times(1)).visit(qm);
-        verify(strictSpy, times(1)).visit(qm);
+        qm.accept(verify(spy, times(1)));
+        qm.accept(verify(strictSpy, times(1)));
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void testStrictVisitBadExp() {
         final FieldExpression exp = new Between(new IntegerFieldValue(HIGH), new IntegerFieldValue(LOW));
-        strictVisitor.visit(exp);
+        exp.accept(strictVisitor);
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void testVisitBadExp() {
         final FieldExpression exp = new Between(new IntegerFieldValue(LOWOOR), new IntegerFieldValue(HIGH));
-        visitor.visit(exp);
+        exp.accept(visitor);
     }
 
     @Test
     public void testVisitAlwaysField() {
         final FieldExpression always = FieldExpression.always();
-        assertEquals(always, strictVisitor.visit(always));
-        assertEquals(always, visitor.visit(always));
+        assertEquals(always, always.accept(strictVisitor));
+        assertEquals(always, always.accept(visitor));
     }
 
     @Test
     public void testVisitQuestionMarkField() {
         final FieldExpression qm = FieldExpression.questionMark();
-        assertEquals(qm, strictVisitor.visit(qm));
-        assertEquals(qm, visitor.visit(qm));
+        assertEquals(qm, qm.accept(strictVisitor));
+        assertEquals(qm, qm.accept(visitor));
     }
 
     @Test
     public void testVisitBetween() {
         Between between = new Between(new IntegerFieldValue(LOW), new IntegerFieldValue(MIDDLE));
-        assertEquals(between, strictVisitor.visit(between));
-        assertEquals(between, visitor.visit(between));
+        assertEquals(between, between.accept(strictVisitor));
+        assertEquals(between, between.accept(visitor));
 
         between = new Between(new IntegerFieldValue(LOW), new SpecialCharFieldValue(SpecialChar.L));
-        assertEquals(between, strictVisitor.visit(between));
-        assertEquals(between, visitor.visit(between));
+        assertEquals(between, between.accept(strictVisitor));
+        assertEquals(between, between.accept(visitor));
 
         between = new Between(new SpecialCharFieldValue(SpecialChar.L), new IntegerFieldValue(MIDDLE));
-        assertEquals(between, strictVisitor.visit(between));
-        assertEquals(between, visitor.visit(between));
+        assertEquals(between, between.accept(strictVisitor));
+        assertEquals(between, between.accept(visitor));
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void testStrictVisitBetweenWrongSpecialChars() {
-        strictVisitor.visit(new Between(new IntegerFieldValue(LOW), new SpecialCharFieldValue(SpecialChar.LW)));
+        new Between(new IntegerFieldValue(LOW), new SpecialCharFieldValue(SpecialChar.LW)).accept(strictVisitor);
 
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void testStrictVisitBetweenOORangeBottom() {
-        strictVisitor.visit(new Between(new IntegerFieldValue(LOWOOR), new IntegerFieldValue(HIGH)));
+        new Between(new IntegerFieldValue(LOWOOR), new IntegerFieldValue(HIGH)).accept(strictVisitor);
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void testStrictVisitBetweenOORangeTop() {
-        strictVisitor.visit(new Between(new IntegerFieldValue(LOW), new IntegerFieldValue(HIGHOOR)));
+        new Between(new IntegerFieldValue(LOW), new IntegerFieldValue(HIGHOOR)).accept(strictVisitor);
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void testStrictVisitBetweenOORange() {
-        strictVisitor.visit(new Between(new IntegerFieldValue(LOWOOR), new IntegerFieldValue(HIGHOOR)));
+        new Between(new IntegerFieldValue(LOWOOR), new IntegerFieldValue(HIGHOOR)).accept(strictVisitor);
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void testStrictVisitBetweenOOOrder() {
-        strictVisitor.visit(new Between(new IntegerFieldValue(HIGH), new IntegerFieldValue(LOW)));
+        new Between(new IntegerFieldValue(HIGH), new IntegerFieldValue(LOW)).accept(strictVisitor);
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void testVisitBetweenWrongSpecialChars() {
-        visitor.visit(new Between(new IntegerFieldValue(LOW), new SpecialCharFieldValue(SpecialChar.LW)));
+        new Between(new IntegerFieldValue(LOW), new SpecialCharFieldValue(SpecialChar.LW)).accept(visitor);
 
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void testVisitBetweenOORangeBottom() {
-        visitor.visit(new Between(new IntegerFieldValue(LOWOOR), new IntegerFieldValue(HIGH)));
+        new Between(new IntegerFieldValue(LOWOOR), new IntegerFieldValue(HIGH)).accept(visitor);
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void testVisitBetweenOORangeTop() {
-        visitor.visit(new Between(new IntegerFieldValue(LOW), new IntegerFieldValue(HIGHOOR)));
+        new Between(new IntegerFieldValue(LOW), new IntegerFieldValue(HIGHOOR)).accept(visitor);
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void testVisitBetweenOORange() {
-        visitor.visit(new Between(new IntegerFieldValue(LOWOOR), new IntegerFieldValue(HIGHOOR)));
+        new Between(new IntegerFieldValue(LOWOOR), new IntegerFieldValue(HIGHOOR)).accept(visitor);
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -229,7 +229,7 @@ public class ValidationFieldExpressionVisitorTest {
         visitor = new ValidationFieldExpressionVisitor(fieldConstraints, stringValidations);
 
         final Between between = new Between(new IntegerFieldValue(HIGH), new IntegerFieldValue(LOW));
-        assertEquals(between, visitor.visit(between));
+        assertEquals(between, between.accept(visitor));
     }
 
     @Test
@@ -240,7 +240,7 @@ public class ValidationFieldExpressionVisitorTest {
         visitor = new ValidationFieldExpressionVisitor(fieldConstraints, stringValidations);
 
         final Between between = new Between(new IntegerFieldValue(HIGH), new IntegerFieldValue(LOW));
-        assertEquals(between, visitor.visit(between));
+        assertEquals(between, between.accept(visitor));
     }
 
     @Test
@@ -249,125 +249,125 @@ public class ValidationFieldExpressionVisitorTest {
         final ValidationFieldExpressionVisitor spy = Mockito.spy(visitor);
         final ValidationFieldExpressionVisitor strictSpy = Mockito.spy(strictVisitor);
 
-        assertEquals(every, spy.visit(every));
-        assertEquals(every, strictSpy.visit(every));
+        assertEquals(every, every.accept(spy));
+        assertEquals(every, every.accept(strictSpy));
 
         final Between between = new Between(new IntegerFieldValue(LOW), new IntegerFieldValue(MIDDLE));
         every = new Every(between, new IntegerFieldValue(HIGH));
-        assertEquals(every, spy.visit(every));
-        assertEquals(every, strictSpy.visit(every));
+        assertEquals(every, every.accept(spy));
+        assertEquals(every, every.accept(strictSpy));
 
-        verify(spy, times(1)).visit(between);
-        verify(strictSpy, times(1)).visit(between);
+        between.accept(verify(spy, times(1)));
+        between.accept(verify(strictSpy, times(1)));
 
         final On on = new On(new IntegerFieldValue(LOW));
 
         every = new Every(on, new IntegerFieldValue(HIGH));
-        assertEquals(every, spy.visit(every));
-        assertEquals(every, strictSpy.visit(every));
+        assertEquals(every, every.accept(spy));
+        assertEquals(every, every.accept(strictSpy));
 
-        verify(spy, times(1)).visit(on);
-        verify(strictSpy, times(1)).visit(on);
+        on.accept(verify(spy, times(1)));
+        on.accept(verify(strictSpy, times(1)));
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void testStrictVisitEveryOORange() {
-        strictVisitor.visit(new Every(new IntegerFieldValue(HIGHOOR)));
+        new Every(new IntegerFieldValue(HIGHOOR)).accept(strictVisitor);
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void testStrictVisitEveryOORangeBetween() {
-        strictVisitor.visit(new Every(new Between(new IntegerFieldValue(LOW), new IntegerFieldValue(MIDDLE)),
-                new IntegerFieldValue(HIGHOOR)));
+        new Every(new Between(new IntegerFieldValue(LOW), new IntegerFieldValue(MIDDLE)),
+                new IntegerFieldValue(HIGHOOR)).accept(strictVisitor);
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void testStrictVisitEveryOORangeOn() {
-        strictVisitor.visit(new Every(new On(new IntegerFieldValue(LOW)), new IntegerFieldValue(HIGHOOR)));
+        new Every(new On(new IntegerFieldValue(LOW)), new IntegerFieldValue(HIGHOOR)).accept(strictVisitor);
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void testStrictVisitEveryOORangeBadBetween() {
-        strictVisitor.visit(new Every(new Between(new IntegerFieldValue(LOWOOR), new IntegerFieldValue(MIDDLE)),
-                new IntegerFieldValue(HIGH)));
+        new Every(new Between(new IntegerFieldValue(LOWOOR), new IntegerFieldValue(MIDDLE)),
+                new IntegerFieldValue(HIGH)).accept(strictVisitor);
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void testStrictVisitEveryOORangeBadOn() {
-        strictVisitor.visit(new Every(new On(new IntegerFieldValue(HIGHOOR)), new IntegerFieldValue(HIGH)));
+        new Every(new On(new IntegerFieldValue(HIGHOOR)), new IntegerFieldValue(HIGH)).accept(strictVisitor);
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void testVisitEveryOORange() {
-        visitor.visit(new Every(new IntegerFieldValue(HIGHOOR)));
+        new Every(new IntegerFieldValue(HIGHOOR)).accept(visitor);
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void testVisitEveryOORangeBetween() {
-        visitor.visit(new Every(new Between(new IntegerFieldValue(LOW), new IntegerFieldValue(MIDDLE)),
-                new IntegerFieldValue(HIGHOOR)));
+        new Every(new Between(new IntegerFieldValue(LOW), new IntegerFieldValue(MIDDLE)),
+                new IntegerFieldValue(HIGHOOR)).accept(visitor);
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void testVisitEveryOORangeOn() {
-        visitor.visit(new Every(new On(new IntegerFieldValue(LOW)), new IntegerFieldValue(HIGHOOR)));
+        new Every(new On(new IntegerFieldValue(LOW)), new IntegerFieldValue(HIGHOOR)).accept(visitor);
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void testVisitEveryOORangeBadBetween() {
-        strictVisitor.visit(new Every(new Between(new IntegerFieldValue(LOWOOR), new IntegerFieldValue(MIDDLE)),
-                new IntegerFieldValue(HIGH)));
+        new Every(new Between(new IntegerFieldValue(LOWOOR), new IntegerFieldValue(MIDDLE)),
+                new IntegerFieldValue(HIGH)).accept(strictVisitor);
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void testVisitEveryOORangeBadOn() {
-        strictVisitor.visit(new Every(new On(new IntegerFieldValue(HIGHOOR)), new IntegerFieldValue(HIGH)));
+        new Every(new On(new IntegerFieldValue(HIGHOOR)), new IntegerFieldValue(HIGH)).accept(strictVisitor);
     }
 
     @Test
     public void testVisitOn() {
         On on = new On(new IntegerFieldValue(LOW));
-        assertEquals(on, strictVisitor.visit(on));
-        assertEquals(on, visitor.visit(on));
+        assertEquals(on, on.accept(strictVisitor));
+        assertEquals(on, on.accept(visitor));
 
         on = new On(new IntegerFieldValue(DEFAULT_INT));
-        assertEquals(on, strictVisitor.visit(on));
-        assertEquals(on, visitor.visit(on));
+        assertEquals(on, on.accept(strictVisitor));
+        assertEquals(on, on.accept(visitor));
 
         on = new On(new SpecialCharFieldValue(SpecialChar.L));
-        assertEquals(on, strictVisitor.visit(on));
-        assertEquals(on, visitor.visit(on));
+        assertEquals(on, on.accept(strictVisitor));
+        assertEquals(on, on.accept(visitor));
 
         on = new On(new IntegerFieldValue(LOW), new SpecialCharFieldValue(SpecialChar.L), new IntegerFieldValue(HIGH));
-        assertEquals(on, strictVisitor.visit(on));
-        assertEquals(on, visitor.visit(on));
+        assertEquals(on, on.accept(strictVisitor));
+        assertEquals(on, on.accept(visitor));
 
         on = new On(new IntegerFieldValue(LOW), new SpecialCharFieldValue(SpecialChar.LW),
                 new IntegerFieldValue(DEFAULT_INT));
-        assertEquals(on, strictVisitor.visit(on));
-        assertEquals(on, visitor.visit(on));
+        assertEquals(on, on.accept(strictVisitor));
+        assertEquals(on, on.accept(visitor));
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void testStrictVisitOnBadTime() {
-        strictVisitor.visit(new On(new IntegerFieldValue(LOWOOR)));
+        new On(new IntegerFieldValue(LOWOOR)).accept(strictVisitor);
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void testStrictVisitOnBadNth() {
-        strictVisitor.visit(new On(new IntegerFieldValue(LOW), new SpecialCharFieldValue(SpecialChar.LW),
-                new IntegerFieldValue(HIGHOOR)));
+        new On(new IntegerFieldValue(LOW), new SpecialCharFieldValue(SpecialChar.LW),
+                new IntegerFieldValue(HIGHOOR)).accept(strictVisitor);
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void testVisitOnBadTime() {
-        visitor.visit(new On(new IntegerFieldValue(LOWOOR)));
+        new On(new IntegerFieldValue(LOWOOR)).accept(visitor);
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void testVisitOnBadNth() {
-        visitor.visit(new On(new IntegerFieldValue(LOW), new SpecialCharFieldValue(SpecialChar.LW),
-                new IntegerFieldValue(HIGHOOR)));
+        new On(new IntegerFieldValue(LOW), new SpecialCharFieldValue(SpecialChar.LW),
+                new IntegerFieldValue(HIGHOOR)).accept(visitor);
     }
 
     @Test
@@ -379,19 +379,19 @@ public class ValidationFieldExpressionVisitorTest {
         final Between b2 = new Between(new IntegerFieldValue(MIDDLE), new IntegerFieldValue(HIGH));
         final On on = new On(new IntegerFieldValue(LOW));
         and.and(b1).and(b2).and(b2).and(on);
-        assertEquals(and, spy.visit(and));
-        assertEquals(and, strictSpy.visit(and));
+        assertEquals(and, and.accept(spy));
+        assertEquals(and, and.accept(strictSpy));
 
-        verify(spy, times(1)).visit(b1);
-        verify(spy, times(2)).visit(b2);
-        verify(spy, times(1)).visit(on);
-        verify(strictSpy, times(1)).visit(b1);
-        verify(strictSpy, times(2)).visit(b2);
-        verify(strictSpy, times(1)).visit(on);
+        b1.accept(verify(spy, times(1)));
+        b2.accept(verify(spy, times(2)));
+        on.accept(verify(spy, times(1)));
+        b1.accept(verify(strictSpy, times(1)));
+        b2.accept(verify(strictSpy, times(2)));
+        on.accept(verify(strictSpy, times(1)));
 
         and = new And();
-        assertEquals(and, visitor.visit(and));
-        assertEquals(and, strictVisitor.visit(and));
+        assertEquals(and, and.accept(visitor));
+        assertEquals(and, and.accept(strictVisitor));
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -401,7 +401,7 @@ public class ValidationFieldExpressionVisitorTest {
         final Between b2 = new Between(new IntegerFieldValue(MIDDLE), new IntegerFieldValue(HIGHOOR));
         final On on = new On(new IntegerFieldValue(LOW));
         and.and(b1).and(b2).and(b2).and(on);
-        strictVisitor.visit(and);
+        and.accept(strictVisitor);
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -411,7 +411,7 @@ public class ValidationFieldExpressionVisitorTest {
         final Between b2 = new Between(new IntegerFieldValue(MIDDLE), new IntegerFieldValue(HIGHOOR));
         final On on = new On(new IntegerFieldValue(LOW));
         and.and(b1).and(b2).and(b2).and(on);
-        visitor.visit(and);
+        and.accept(visitor);
     }
 
     @Test

--- a/src/test/java/com/cronutils/model/field/expression/visitor/ValueMappingFieldExpressionVisitorTest.java
+++ b/src/test/java/com/cronutils/model/field/expression/visitor/ValueMappingFieldExpressionVisitorTest.java
@@ -34,7 +34,7 @@ public class ValueMappingFieldExpressionVisitorTest {
     @Test
     public void testVisitQuestionMark() {
         final FieldExpression param = FieldExpression.questionMark();
-        final QuestionMark questionMark = (QuestionMark) valueMappingFieldExpressionVisitor.visit(param);
+        final QuestionMark questionMark = (QuestionMark) param.accept(valueMappingFieldExpressionVisitor);
         assertTrue(param == questionMark);//always the same cause of singleton pattern
     }
 }


### PR DESCRIPTION
This is the more usual way the visitor pattern is implemented. It avoids
requiring a bunch of explicit instanceof tests for each sub-type.

Also, add a FieldExpressionVisitorAdaptor utility class.