### PR TITLE
Add an Automatic-Module-Name

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -241,6 +241,9 @@
                             <addClasspath>true</addClasspath>
                             <!--mainClass>com.cronutils.cli.CronUtilsCLI</mainClass-->
                         </manifest>
+                        <manifestEntries>
+                            <Automatic-Module-Name>com.cronutils</Automatic-Module-Name>
+                        </manifestEntries>
                     </archive>
                 </configuration>
             </plugin>


### PR DESCRIPTION
This allows the project to be used with JPMS, though not `jlink`. In the future, the project should likely be fully modularized to allow usage with `jlink`.