### PR TITLE
CronScheduler feature using JDKs ScheduledExecutorService

### DIFF
--- a/src/main/java/com/cronutils/scheduler/CronJob.java
+++ b/src/main/java/com/cronutils/scheduler/CronJob.java
@@ -1,0 +1,91 @@
+package com.cronutils.scheduler;
+
+import com.cronutils.model.time.ExecutionTime;
+import java.time.ZonedDateTime;
+import java.time.temporal.ChronoUnit;
+import java.util.Optional;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * A CronJob scheduled by {@link CronScheduler} that executes a tasks and plans the next execution time.
+ *
+ * @author norbertroamsys
+ */
+class CronJob implements Runnable {
+
+    private final ScheduledExecutorService executorService;
+    private final ExecutionTime executionTime;
+    private final Runnable job;
+
+    private ZonedDateTime nextExecution;
+    private ScheduledFuture<?> scheduledFuture;
+    private volatile boolean canceled;
+
+    /**
+     * Constructor.
+     *
+     * @param executorService the executer service for sequential scheduling
+     * @param executionTime the execution time calculator
+     * @param job the callback that should be executed
+     */
+    CronJob(final ScheduledExecutorService executorService, final ExecutionTime executionTime, final Runnable job) {
+        this.executorService = executorService;
+        this.executionTime = executionTime;
+        this.job = job;
+        // do the first planing using current time
+        scheduleNext(ZonedDateTime.now());
+    }
+
+    /**
+     * Returns the next time the job will be start executing.
+     *
+     * @return the date and time or <code>null</code>
+     */
+    public ZonedDateTime getNextExecution() {
+        return nextExecution;
+    }
+
+    @Override
+    public void run() {
+        if (!canceled) {
+            job.run();
+        }
+        if (!canceled) {
+            scheduleNext(nextExecution);
+        }
+    }
+
+    /**
+     * Plans the next execution time to run this job again.
+     *
+     * @param timeStamp the reference time stamp
+     */
+    private void scheduleNext(final ZonedDateTime timeStamp) {
+        final Optional<ZonedDateTime> next = executionTime.nextExecution(timeStamp);
+        if (next.isPresent()) {
+            nextExecution = next.get();
+            final long delay = ChronoUnit.MILLIS.between(timeStamp, nextExecution);
+            scheduledFuture = executorService.schedule(this, delay, TimeUnit.MILLISECONDS);
+        } else {
+            // job maybe defined to run only once
+            scheduledFuture = null;
+        }
+    }
+
+    /**
+     * Cancels the job.
+     *
+     * @return whether the job has really been canceled
+     */
+    public boolean cancel() {
+        canceled = true;
+        if (scheduledFuture != null) {
+            return scheduledFuture.cancel(false);
+        } else {
+            return false;
+        }
+    }
+
+}

--- a/src/main/java/com/cronutils/scheduler/CronScheduler.java
+++ b/src/main/java/com/cronutils/scheduler/CronScheduler.java
@@ -1,0 +1,100 @@
+package com.cronutils.scheduler;
+
+import com.cronutils.model.Cron;
+import com.cronutils.model.time.ExecutionTime;
+import java.time.ZonedDateTime;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+
+/**
+ * Simple scheduler for starting jobs using JDKs {@link ScheduledExecutorService}.
+ *
+ * @param <I> type of ID
+ * @author norbertroamsys
+ */
+public class CronScheduler<I> {
+
+    // the executer service for scheduling the CronJobs.
+    private final ScheduledExecutorService executorService;
+    // the registry about scheduled jobs
+    private final Map<I, CronJob> scheduledCronJobs;
+
+    /**
+     * Default constructor using a single thread executor.
+     */
+    public CronScheduler() {
+        this(Executors.newSingleThreadScheduledExecutor());
+    }
+
+    /**
+     * Constructor for using a thread executor pool.
+     *
+     * @param threadPoolSize the number of threads to keep in the pool, even if they are idle
+     */
+    public CronScheduler(final int threadPoolSize) {
+        this(Executors.newScheduledThreadPool(threadPoolSize));
+    }
+
+    private CronScheduler(final ScheduledExecutorService executorService) {
+        this.executorService = executorService;
+        this.scheduledCronJobs = Collections.synchronizedMap(new HashMap<>());
+    }
+
+    /**
+     * Adds a job to be executed defined by given cron expression.
+     *
+     * @param id the unique ID of the job
+     * @param cron the cron expression
+     * @param job the callback that should be executed
+     * @return <code>true</code> if the job has been added successfully
+     */
+    public boolean addCronJob(final I id, final Cron cron, final Runnable job) {
+        if (!scheduledCronJobs.containsKey(id)) {
+            scheduledCronJobs.put(id, new CronJob(executorService, ExecutionTime.forCron(cron), job));
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    /**
+     * Returns the next time the job will be start executing.
+     *
+     * @param id the unique ID of the job
+     * @return the date and time or <code>null</code>
+     */
+    public ZonedDateTime getNextCronJobExecution(final I id) {
+        if (scheduledCronJobs.containsKey(id)) {
+            return scheduledCronJobs.get(id).getNextExecution();
+        } else {
+            return null;
+        }
+    }
+
+    /**
+     * Removes a job formally added. The job execution will also be canceled.
+     *
+     * @param id the unique ID of the job
+     * @return <code>true</code> if the job has been removed successfully
+     */
+    public boolean removeCronJob(final I id) {
+        if (scheduledCronJobs.containsKey(id)) {
+            return scheduledCronJobs.remove(id).cancel();
+        } else {
+            return false;
+        }
+    }
+
+    /**
+     * Shuts down the scheduler by canceling all jobs and also shutting down the {@link ScheduledExecutorService}.
+     * <b>Please note that this scheduler can't be used after the shutdown was invoked!</b>
+     */
+    public void shutdown() {
+        scheduledCronJobs.values().forEach(CronJob::cancel);
+        scheduledCronJobs.clear();
+        executorService.shutdown();
+    }
+}

--- a/src/test/java/com/cronutils/scheduler/CronSchedulerTest.java
+++ b/src/test/java/com/cronutils/scheduler/CronSchedulerTest.java
@@ -1,0 +1,62 @@
+package com.cronutils.scheduler;
+
+import com.cronutils.model.Cron;
+import com.cronutils.model.CronType;
+import com.cronutils.model.definition.CronDefinitionBuilder;
+import com.cronutils.parser.CronParser;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Tests for {@link CronScheduler}.
+ *
+ * @author norbertroamsys
+ */
+public class CronSchedulerTest {
+
+    private int secondsJobRunCount;
+    private int twoSecondsJobRunCount;
+
+    /**
+     * Tests scheduler by processing two parallel jobs for overall 15 seconds.
+     */
+    @Test
+    public void testScheduler() throws InterruptedException {
+        final CronScheduler<Integer> cronScheduler = new CronScheduler<>();
+        final CronParser parser = new CronParser(CronDefinitionBuilder.instanceDefinitionFor(CronType.SPRING));
+
+        final Cron everySecondJob = parser.parse("*/1 * * * * *");
+        final Cron everyTwoSecondsJob = parser.parse("*/2 * * * * *");
+
+        // register two jobs
+        Assert.assertTrue(cronScheduler.addCronJob(1, everySecondJob, () -> secondsJobRunCount++));
+        Assert.assertTrue(cronScheduler.addCronJob(2, everyTwoSecondsJob, () -> twoSecondsJobRunCount++));
+
+        // let the jobs do there work for 10 seconds
+        Thread.sleep(10000);
+
+        Assert.assertTrue("Every-second job should be called", secondsJobRunCount > 0);
+        Assert.assertTrue("Every-two-seconds job should be called", twoSecondsJobRunCount > 0);
+        Assert.assertTrue("Every-second job should be called not more than 10 times", secondsJobRunCount <= 10);
+        Assert.assertTrue("Every-two-second job should be called not more than 5 times", twoSecondsJobRunCount <= 5);
+        Assert.assertTrue("Every-second job should be called more often than every-two-seconds job", secondsJobRunCount > twoSecondsJobRunCount);
+
+        // take a snapshot for the counts so far
+        final int secondsJobRunCountSnapshot = secondsJobRunCount;
+        final int twoSecondsJobRunCountSnapshot = twoSecondsJobRunCount;
+
+        Assert.assertTrue(cronScheduler.removeCronJob(1));
+
+        // let one job do more work for 5 seconds
+        Thread.sleep(5000);
+
+        Assert.assertEquals("Every-second job should no longer be called because it has been removed", secondsJobRunCountSnapshot, secondsJobRunCount);
+        Assert.assertTrue("Every-two-second job should be called again because it is still active", secondsJobRunCount > twoSecondsJobRunCountSnapshot);
+
+        // shutdown completely
+        cronScheduler.shutdown();
+
+        Assert.assertFalse("Every-two-second job should already be removed by shutdown", cronScheduler.removeCronJob(2));
+    }
+
+}


### PR DESCRIPTION
Hi cron-utils core developers!

We are using this library since the beginning of this year and found it really helpful and easy to use. Well done guys 👍!

We use the parsing of cron expressions and also the describe functionality.  
For executing our jobs we decided not to use quartz-scheduler or Spring because our requirements are quite simple.
We decided to create a simple scheduler based on your `ExecutionTime` class.
The only additional dependency is Javas `ScheduledExecutorService`. 

We thing this approach maybe sufficient for other users too.
That's why we wanted to share the code with you and asking you to verify whether this makes sense!
Of course: Cron-utils focus is not for providing a scheduling framework like quarz. But this couple of code lines is far away from that indeed ;-).  

The JUnit test should show the general functionality.
If you prefer a different packaging or code styling please feel free to comment and request for this.
An additional chapter for the README.md can also be provided.
We are also not angry if you decide to close the pull request because such kind of feature are out of scope for you.

Looking forward to hear from you ...
 
 

