### PR TITLE
Fix mapping of interval for the day of week

### DIFF
--- a/src/main/java/com/cronutils/parser/FieldParser.java
+++ b/src/main/java/com/cronutils/parser/FieldParser.java
@@ -120,7 +120,7 @@ public class FieldParser {
         if (ASTERISK.equals(trimmedStart) || EMPTY_STRING.equals(start.trim())) {
             return new Every(new IntegerFieldValue(Integer.parseInt(value)));
         } else {
-            return new Every(new On(new IntegerFieldValue(Integer.parseInt(start))), new IntegerFieldValue(Integer.parseInt(value)));
+            return new Every(new On(mapToIntegerFieldValue(start)), new IntegerFieldValue(Integer.parseInt(value)));
         }
     }
 

--- a/src/test/java/com/cronutils/mapper/CronMapperIntegrationTest.java
+++ b/src/test/java/com/cronutils/mapper/CronMapperIntegrationTest.java
@@ -70,8 +70,8 @@ public class CronMapperIntegrationTest {
 
     @Test
     public void testDaysOfWeekUnixToQuartz() {
-        final String input = "* * * * 3,5-6";
-        final String expected = "0 * * ? * 4,6-7 *";
+        final String input = "* * * * 3,5-6,*/2,2/3,7/4";
+        final String expected = "0 * * ? * 4,6-7,*/2,3/3,1/4 *";
         assertEquals(expected, CronMapper.fromUnixToQuartz().map(unixParser().parse(input)).asString());
     }
 


### PR DESCRIPTION
It fixes how the mapper handle the day of the week, leaving the interval untouched, but mapping the start day if present.
Also fixes the int mapping when parsing. In unix "7/3" should be parsed as "0/3"

Fixes #495