### PR TITLE
Fix exception thrown when DoW set as Sunday using QUARTZ definition #508

### DIFF
--- a/src/main/java/com/cronutils/mapper/WeekDay.java
+++ b/src/main/java/com/cronutils/mapper/WeekDay.java
@@ -61,7 +61,7 @@ public class WeekDay implements Serializable {
             return mapTo(dayOfWeek, new WeekDay(targetWeekDayDefinition.getMondayDoWValue() + 1, false)) - 1;
         } else {
             //my range is 0-6. I normalize ranges, get the "one" mapping and turn result into original scale
-            return mapTo(dayOfWeek, new WeekDay(targetWeekDayDefinition.getMondayDoWValue() - 1, true)) + 1;
+            return (mapTo(dayOfWeek, new WeekDay(targetWeekDayDefinition.getMondayDoWValue() - 1, true))) % 7 + 1;
         }
     }
 

--- a/src/test/java/com/cronutils/model/definition/CronDefinitionBuilderTest.java
+++ b/src/test/java/com/cronutils/model/definition/CronDefinitionBuilderTest.java
@@ -186,6 +186,28 @@ public class CronDefinitionBuilderTest {
         assertEquals("0 0 12 ? * 6 *", result);
     }
 
+    /**
+     * Test for issue https://github.com/jmrozanec/cron-utils/issues/508
+     * DoW as Sunday using QUARTZ definition was going out of range [1,7]
+     */
+    @Test
+    public void testDoWProperWeekdayOffsetForSunday(){
+        CronDefinition cronDefinition = CronDefinitionBuilder.instanceDefinitionFor(CronType.QUARTZ);
+        CronBuilder builder = CronBuilder.cron(cronDefinition)
+                .withYear(always())
+                .withMonth(always())
+                .withDoW(on(Weekdays.SUNDAY.getWeekday(cronDefinition)))
+                .withDoM(questionMark())
+                .withHour(on(12))
+                .withMinute(on(0))
+                .withSecond(on(0));
+
+        Cron cron = builder.instance();
+        String result = cron.asString();
+
+        assertEquals("0 0 12 ? * 1 *", result);
+    }
+
     @Test
     public void testSpringSchedule(){
         CronDefinition cronDefinition = CronDefinitionBuilder.instanceDefinitionFor(CronType.SPRING);


### PR DESCRIPTION
It fixes the DoW to be map Sunday correctly to 1 instead of 8.
Have also included the unit test for the issue.

Fixes #508