### PR TITLE
Equals and hashcode for FieldConstraints and FieldDefinition

### DIFF
--- a/src/main/java/com/cronutils/model/field/constraint/FieldConstraints.java
+++ b/src/main/java/com/cronutils/model/field/constraint/FieldConstraints.java
@@ -19,6 +19,7 @@ import com.cronutils.utils.Preconditions;
 import java.io.Serializable;
 import java.util.Collections;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 
 /**
@@ -99,5 +100,20 @@ public class FieldConstraints implements Serializable {
 
     public boolean isStrictRange() {
         return strictRange;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        FieldConstraints that = (FieldConstraints) o;
+        return strictRange == that.strictRange && stringMapping.equals(that.stringMapping)
+                && intMapping.equals(that.intMapping) && specialChars.equals(that.specialChars)
+                && startRange.equals(that.startRange) && endRange.equals(that.endRange);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(stringMapping, intMapping, specialChars, startRange, endRange, strictRange);
     }
 }

--- a/src/main/java/com/cronutils/model/field/definition/FieldDefinition.java
+++ b/src/main/java/com/cronutils/model/field/definition/FieldDefinition.java
@@ -19,6 +19,7 @@ import com.cronutils.utils.Preconditions;
 
 import java.io.Serializable;
 import java.util.Comparator;
+import java.util.Objects;
 
 /**
  * Represents a definition of allowed values for a cron field.
@@ -91,6 +92,19 @@ public class FieldDefinition implements Serializable {
      */
     public static Comparator<FieldDefinition> createFieldDefinitionComparator() {
         return Comparator.comparingInt(o -> o.getFieldName().getOrder());
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        FieldDefinition that = (FieldDefinition) o;
+        return optional == that.optional && fieldName == that.fieldName && constraints.equals(that.constraints);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(fieldName, constraints, optional);
     }
 }
 


### PR DESCRIPTION
Necessary to get proper behavior for equals and hashcode in `CronDefinition`.

I also corrected the test class, the original tests were misleading because they used the very same instance of `FieldDefinition`s.

See #507 and #516