### PR TITLE
Make jakarta.el implementation provided

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -153,6 +153,7 @@
             <groupId>org.glassfish</groupId>
             <artifactId>jakarta.el</artifactId>
             <version>3.0.4</version>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.projectlombok</groupId>


### PR DESCRIPTION
Given the API is provided, I think it was the original intent.
From what I can see, it is only useful when using Hibernate Validator
and, in this case, users should push their EL implementation.