### PR TITLE
Standardize tests to use JUnit Jupiter

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -62,7 +62,6 @@
         <slf4j.version>1.7.30</slf4j.version>
         <junit.version>5.8.1</junit.version>
         <mockito.version>3.9.0</mockito.version>
-        <powermock.version>2.0.9</powermock.version>
 
         <github.global.server>github</github.global.server>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -98,7 +97,7 @@
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-junit-jupiter</artifactId>
+            <artifactId>mockito-inline</artifactId>
             <version>${mockito.version}</version>
             <scope>test</scope>
         </dependency>
@@ -106,18 +105,6 @@
             <groupId>pl.pragmatists</groupId>
             <artifactId>JUnitParams</artifactId>
             <version>1.1.1</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.powermock</groupId>
-            <artifactId>powermock-module-junit4</artifactId>
-            <version>${powermock.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.powermock</groupId>
-            <artifactId>powermock-api-mockito2</artifactId>
-            <version>${powermock.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -91,7 +91,7 @@
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter-api</artifactId>
+            <artifactId>junit-jupiter</artifactId>
             <version>${junit.version}</version>
             <scope>test</scope>
         </dependency>
@@ -99,12 +99,6 @@
             <groupId>org.mockito</groupId>
             <artifactId>mockito-inline</artifactId>
             <version>${mockito.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>pl.pragmatists</groupId>
-            <artifactId>JUnitParams</artifactId>
-            <version>1.1.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/pom.xml.jdk16
+++ b/pom.xml.jdk16
@@ -91,7 +91,7 @@
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter-api</artifactId>
+            <artifactId>junit-jupiter</artifactId>
             <version>${junit.version}</version>
             <scope>test</scope>
         </dependency>

--- a/pom.xml.jdk16
+++ b/pom.xml.jdk16
@@ -62,7 +62,6 @@
         <slf4j.version>1.7.30</slf4j.version>
         <junit.version>5.8.1</junit.version>
         <mockito.version>3.9.0</mockito.version>
-        <powermock.version>2.0.9</powermock.version>
 
         <github.global.server>github</github.global.server>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -98,20 +97,8 @@
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-junit-jupiter</artifactId>
+            <artifactId>mockito-inline</artifactId>
             <version>${mockito.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.powermock</groupId>
-            <artifactId>powermock-module-junit4</artifactId>
-            <version>${powermock.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.powermock</groupId>
-            <artifactId>powermock-api-mockito2</artifactId>
-            <version>${powermock.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/src/test/java/com/cronutils/Issue143Test.java
+++ b/src/test/java/com/cronutils/Issue143Test.java
@@ -17,7 +17,6 @@ import com.cronutils.model.CronType;
 import com.cronutils.model.definition.CronDefinitionBuilder;
 import com.cronutils.model.time.ExecutionTime;
 import com.cronutils.parser.CronParser;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -26,6 +25,7 @@ import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.util.Optional;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
 public class Issue143Test {
@@ -51,7 +51,7 @@ public class Issue143Test {
 
         ZonedDateTime expected = ZonedDateTime.of(LocalDateTime.of(2015, 12, 31, 12, 0),
                 ZoneId.systemDefault());
-        Assert.assertEquals(expected, last);
+        assertEquals(expected, last);
     }
 
     @Test
@@ -60,7 +60,7 @@ public class Issue143Test {
         final Optional<ZonedDateTime> lastExecution = et.lastExecution(currentDateTime);
         if (lastExecution.isPresent()) {
             final ZonedDateTime expected = ZonedDateTime.of(LocalDateTime.of(2012, 12, 29, 12, 0), ZoneId.systemDefault());
-            Assert.assertEquals(expected, lastExecution.get());
+            assertEquals(expected, lastExecution.get());
         } else {
             fail(LAST_EXECUTION_NOT_PRESENT_ERROR);
         }
@@ -72,7 +72,7 @@ public class Issue143Test {
         final Optional<ZonedDateTime> lastExecution = et.lastExecution(currentDateTime);
         if (lastExecution.isPresent()) {
             final ZonedDateTime expected = ZonedDateTime.of(LocalDateTime.of(2016, 10, 31, 12, 0), ZoneId.systemDefault());
-            Assert.assertEquals(expected, lastExecution.get());
+            assertEquals(expected, lastExecution.get());
         } else {
             fail(LAST_EXECUTION_NOT_PRESENT_ERROR);
         }
@@ -84,7 +84,7 @@ public class Issue143Test {
         final Optional<ZonedDateTime> lastExecution = et.lastExecution(currentDateTime);
         if (lastExecution.isPresent()) {
             final ZonedDateTime expected = ZonedDateTime.of(LocalDateTime.of(2016, 10, 29, 12, 0), ZoneId.systemDefault());
-            Assert.assertEquals(expected, lastExecution.get());
+            assertEquals(expected, lastExecution.get());
         } else {
             fail(LAST_EXECUTION_NOT_PRESENT_ERROR);
         }

--- a/src/test/java/com/cronutils/Issue143Test.java
+++ b/src/test/java/com/cronutils/Issue143Test.java
@@ -17,16 +17,16 @@ import com.cronutils.model.CronType;
 import com.cronutils.model.definition.CronDefinitionBuilder;
 import com.cronutils.model.time.ExecutionTime;
 import com.cronutils.parser.CronParser;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.util.Optional;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class Issue143Test {
 
@@ -34,7 +34,7 @@ public class Issue143Test {
     private CronParser parser;
     private ZonedDateTime currentDateTime;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         // Make sure that current date is before Dec-31
         currentDateTime = ZonedDateTime.of(LocalDateTime.of(2016, 12, 20, 12, 0),

--- a/src/test/java/com/cronutils/Issue200Test.java
+++ b/src/test/java/com/cronutils/Issue200Test.java
@@ -18,13 +18,13 @@ import com.cronutils.model.definition.CronDefinition;
 import com.cronutils.model.definition.CronDefinitionBuilder;
 import com.cronutils.model.time.ExecutionTime;
 import com.cronutils.parser.CronParser;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 
 import static com.cronutils.model.CronType.QUARTZ;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Created by johnpatrick.manalo on 6/19/17.
@@ -45,7 +45,7 @@ public class Issue200Test {
         final ZonedDateTime zdt = ZonedDateTime.of(1999, 07, 18, 10, 00, 00, 03, ZoneId.systemDefault());
 
         // Must be true
-        assertTrue("Nano seconds must not affect matching of Cron Expressions", ExecutionTime.forCron(quartzCron).isMatch(zdt));
+        assertTrue(ExecutionTime.forCron(quartzCron).isMatch(zdt), "Nano seconds must not affect matching of Cron Expressions");
     }
 
     // Nano second-perfect (passes, no surprises here)
@@ -61,6 +61,6 @@ public class Issue200Test {
 
         final ZonedDateTime zdt = ZonedDateTime.of(1999, 07, 18, 10, 00, 00, 00, ZoneId.systemDefault());
 
-        assertTrue("Nano seconds must not affect matching of Cron Expressions", ExecutionTime.forCron(quartzCron).isMatch(zdt));
+        assertTrue(ExecutionTime.forCron(quartzCron).isMatch(zdt), "Nano seconds must not affect matching of Cron Expressions");
     }
 }

--- a/src/test/java/com/cronutils/Issue215Test.java
+++ b/src/test/java/com/cronutils/Issue215Test.java
@@ -18,7 +18,7 @@ import com.cronutils.model.CronType;
 import com.cronutils.model.definition.CronDefinitionBuilder;
 import com.cronutils.model.time.ExecutionTime;
 import com.cronutils.parser.CronParser;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.time.LocalDateTime;
 import java.time.Month;
@@ -26,7 +26,7 @@ import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.util.Optional;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class Issue215Test {
 

--- a/src/test/java/com/cronutils/Issue218Test.java
+++ b/src/test/java/com/cronutils/Issue218Test.java
@@ -17,7 +17,7 @@ import com.cronutils.model.Cron;
 import com.cronutils.model.definition.CronDefinition;
 import com.cronutils.model.time.ExecutionTime;
 import com.cronutils.parser.CronParser;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.time.ZonedDateTime;
 

--- a/src/test/java/com/cronutils/Issue223Test.java
+++ b/src/test/java/com/cronutils/Issue223Test.java
@@ -19,13 +19,13 @@ import com.cronutils.model.definition.CronDefinition;
 import com.cronutils.model.definition.CronDefinitionBuilder;
 import com.cronutils.model.time.ExecutionTime;
 import com.cronutils.parser.CronParser;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.time.ZonedDateTime;
 import java.util.Optional;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class Issue223Test {
 

--- a/src/test/java/com/cronutils/Issue228Test.java
+++ b/src/test/java/com/cronutils/Issue228Test.java
@@ -18,12 +18,12 @@ import com.cronutils.model.definition.CronDefinition;
 import com.cronutils.model.definition.CronDefinitionBuilder;
 import com.cronutils.model.time.ExecutionTime;
 import com.cronutils.parser.CronParser;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.time.ZonedDateTime;
 import java.util.Optional;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class Issue228Test {
 

--- a/src/test/java/com/cronutils/Issue293Test.java
+++ b/src/test/java/com/cronutils/Issue293Test.java
@@ -6,45 +6,29 @@ import com.cronutils.model.definition.CronDefinition;
 import com.cronutils.model.definition.CronDefinitionBuilder;
 import com.cronutils.model.time.ExecutionTime;
 import com.cronutils.parser.CronParser;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import java.time.DayOfWeek;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.util.Optional;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
 // https://github.com/jmrozanec/cron-utils/issues/293
-@RunWith(Parameterized.class)
 public class Issue293Test {
     private static final ZoneId ZONE = ZoneId.systemDefault();
 
-    private final String cronText;
-
-    /**
-     * Each test is a cron spec excluding the reference month (December)
-     * @return unix cron
-     */
-    @Parameterized.Parameters(name = "{0}")
-    public static String[] data() {
-        return new String[] {
-            "15 18 * 1-11 *",       // DateTimeException - Invalid date - Nov 31
-            "15 18 * 1-11 0-5",     // DateTimeException - Invalid date - Nov 31
-            "15 18 * 1-11 4-5",     // Actual is 11/24
-            "15 18 * 1-11 1-5"      // Actual is 11/29
-        };
-    }
-
-    public Issue293Test(String cronText) {
-        this.cronText = cronText;
-    }
-
-    @Test
-    public void test() {
+    @ParameterizedTest
+    @ValueSource(strings = {
+        "15 18 * 1-11 *",       // DateTimeException - Invalid date - Nov 31
+        "15 18 * 1-11 0-5",     // DateTimeException - Invalid date - Nov 31
+        "15 18 * 1-11 4-5",     // Actual is 11/24
+        "15 18 * 1-11 1-5"      // Actual is 11/29
+    })
+    public void test(String cronText) {
         CronDefinition def = CronDefinitionBuilder.instanceDefinitionFor(CronType.UNIX);
         CronParser parser = new CronParser(def);
 

--- a/src/test/java/com/cronutils/Issue305Test.java
+++ b/src/test/java/com/cronutils/Issue305Test.java
@@ -6,7 +6,7 @@ import com.cronutils.model.definition.CronDefinition;
 import com.cronutils.model.definition.CronDefinitionBuilder;
 import com.cronutils.model.time.ExecutionTime;
 import com.cronutils.parser.CronParser;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
@@ -16,7 +16,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class Issue305Test {
 

--- a/src/test/java/com/cronutils/Issue319Test.java
+++ b/src/test/java/com/cronutils/Issue319Test.java
@@ -5,7 +5,7 @@ import com.cronutils.model.CronType;
 import com.cronutils.model.definition.CronDefinitionBuilder;
 import com.cronutils.model.time.ExecutionTime;
 import com.cronutils.parser.CronParser;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.time.ZoneId;
 import java.time.ZonedDateTime;

--- a/src/test/java/com/cronutils/Issue329Test.java
+++ b/src/test/java/com/cronutils/Issue329Test.java
@@ -5,7 +5,7 @@ import com.cronutils.model.CronType;
 import com.cronutils.model.definition.CronDefinitionBuilder;
 import com.cronutils.model.time.ExecutionTime;
 import com.cronutils.parser.CronParser;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.time.ZonedDateTime;
 

--- a/src/test/java/com/cronutils/Issue332Test.java
+++ b/src/test/java/com/cronutils/Issue332Test.java
@@ -5,7 +5,7 @@ import com.cronutils.model.CronType;
 import com.cronutils.model.definition.CronDefinitionBuilder;
 import com.cronutils.model.time.ExecutionTime;
 import com.cronutils.parser.CronParser;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.time.ZoneId;
 import java.time.ZonedDateTime;

--- a/src/test/java/com/cronutils/Issue338Test.java
+++ b/src/test/java/com/cronutils/Issue338Test.java
@@ -5,11 +5,11 @@ import com.cronutils.model.Cron;
 import com.cronutils.model.CronType;
 import com.cronutils.model.definition.CronDefinitionBuilder;
 import com.cronutils.parser.CronParser;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Locale;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class Issue338Test {
 

--- a/src/test/java/com/cronutils/Issue338Test.java
+++ b/src/test/java/com/cronutils/Issue338Test.java
@@ -5,10 +5,11 @@ import com.cronutils.model.Cron;
 import com.cronutils.model.CronType;
 import com.cronutils.model.definition.CronDefinitionBuilder;
 import com.cronutils.parser.CronParser;
-import org.junit.Assert;
 import org.junit.Test;
 
 import java.util.Locale;
+
+import static org.junit.Assert.assertEquals;
 
 public class Issue338Test {
 
@@ -18,6 +19,6 @@ public class Issue338Test {
 		String cronString = "* * * * * ? *";
 		Cron cron = cronParser.parse(cronString);
 		String description = CronDescriptor.instance(Locale.FRANCE).describe(cron);
-		Assert.assertEquals("chaque seconde", description);
+		assertEquals("chaque seconde", description);
 	}
 }

--- a/src/test/java/com/cronutils/Issue340Test.java
+++ b/src/test/java/com/cronutils/Issue340Test.java
@@ -5,7 +5,6 @@ import com.cronutils.model.definition.CronDefinition;
 import com.cronutils.model.definition.CronDefinitionBuilder;
 import com.cronutils.model.time.ExecutionTime;
 import com.cronutils.parser.CronParser;
-import org.junit.Assert;
 import org.junit.Test;
 import org.mockito.internal.util.collections.Sets;
 
@@ -15,6 +14,8 @@ import java.util.Optional;
 import java.util.Set;
 
 import static com.cronutils.model.CronType.QUARTZ;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 public class Issue340Test {
 
@@ -30,8 +31,8 @@ public class Issue340Test {
 
         // Time from last execution to now
         Optional<Duration> timeFromLastExecution = executionTime.timeFromLastExecution(time);
-        Assert.assertTrue(timeFromLastExecution.isPresent());
-        Assert.assertTrue(timeFromLastExecution.get().toMinutes() <= 60);
+        assertTrue(timeFromLastExecution.isPresent());
+        assertTrue(timeFromLastExecution.get().toMinutes() <= 60);
     }
 
     @Test
@@ -50,13 +51,13 @@ public class Issue340Test {
         // Check the next 100 execution times
         for (int i = 0; i < 100; i++) {
             Optional<ZonedDateTime> nextExecution = executionTime.nextExecution(time);
-            Assert.assertTrue(nextExecution.isPresent());
+            assertTrue(nextExecution.isPresent());
             time = nextExecution.get();
             int dayOfWeek = time.getDayOfWeek().getValue();
-            Assert.assertTrue(validDaysOfWeek.contains(dayOfWeek));
-            Assert.assertEquals(5, time.getHour());
-            Assert.assertEquals(0, time.getMinute());
-            Assert.assertEquals(0, time.getSecond());
+            assertTrue(validDaysOfWeek.contains(dayOfWeek));
+            assertEquals(5, time.getHour());
+            assertEquals(0, time.getMinute());
+            assertEquals(0, time.getSecond());
         }
     }
 

--- a/src/test/java/com/cronutils/Issue340Test.java
+++ b/src/test/java/com/cronutils/Issue340Test.java
@@ -5,7 +5,7 @@ import com.cronutils.model.definition.CronDefinition;
 import com.cronutils.model.definition.CronDefinitionBuilder;
 import com.cronutils.model.time.ExecutionTime;
 import com.cronutils.parser.CronParser;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mockito.internal.util.collections.Sets;
 
 import java.time.Duration;
@@ -14,8 +14,8 @@ import java.util.Optional;
 import java.util.Set;
 
 import static com.cronutils.model.CronType.QUARTZ;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class Issue340Test {
 

--- a/src/test/java/com/cronutils/Issue363Test.java
+++ b/src/test/java/com/cronutils/Issue363Test.java
@@ -4,14 +4,14 @@ import com.cronutils.model.CronType;
 import com.cronutils.model.definition.CronDefinitionBuilder;
 import com.cronutils.model.time.ExecutionTime;
 import com.cronutils.parser.CronParser;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.util.Optional;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class Issue363Test {
 

--- a/src/test/java/com/cronutils/Issue367Test.java
+++ b/src/test/java/com/cronutils/Issue367Test.java
@@ -17,9 +17,9 @@ import com.cronutils.model.Cron;
 import com.cronutils.model.CronType;
 import com.cronutils.model.definition.CronDefinitionBuilder;
 import com.cronutils.parser.CronParser;
-import org.junit.Before;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 import java.text.ParseException;
 import java.time.ZoneId;
@@ -28,17 +28,17 @@ import java.time.format.DateTimeFormatter;
 import java.util.Date;
 import java.util.TimeZone;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Provide an example on how convert a cron expression to ISO8601
  */
-@Ignore
+@Disabled
 public class Issue367Test {
 
 	private CronParser parser;
 
-	@Before
+	@BeforeEach
 	public void setUp() {
 		parser = new CronParser(CronDefinitionBuilder.instanceDefinitionFor(CronType.QUARTZ));
 	}

--- a/src/test/java/com/cronutils/Issue382Test.java
+++ b/src/test/java/com/cronutils/Issue382Test.java
@@ -5,13 +5,13 @@ import com.cronutils.model.CronType;
 import com.cronutils.model.definition.CronDefinitionBuilder;
 import com.cronutils.model.time.ExecutionTime;
 import com.cronutils.parser.CronParser;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.time.ZonedDateTime;
 
 import static java.time.Duration.ofMillis;
 import static java.time.ZoneOffset.UTC;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class Issue382Test {
 

--- a/src/test/java/com/cronutils/Issue388Test.java
+++ b/src/test/java/com/cronutils/Issue388Test.java
@@ -5,14 +5,14 @@ import com.cronutils.model.CronType;
 import com.cronutils.model.definition.CronDefinitionBuilder;
 import com.cronutils.model.time.ExecutionTime;
 import com.cronutils.parser.CronParser;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.time.DayOfWeek;
 import java.time.ZonedDateTime;
 
 import static java.time.ZoneOffset.UTC;
 import static java.time.temporal.TemporalAdjusters.firstInMonth;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 
 public class Issue388Test {

--- a/src/test/java/com/cronutils/Issue394Test.java
+++ b/src/test/java/com/cronutils/Issue394Test.java
@@ -4,15 +4,15 @@ import com.cronutils.model.definition.CronDefinition;
 import com.cronutils.model.definition.CronDefinitionBuilder;
 import com.cronutils.model.time.ExecutionTime;
 import com.cronutils.parser.CronParser;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.time.DayOfWeek;
 import java.time.ZonedDateTime;
 import java.util.Optional;
 
 import static com.cronutils.model.CronType.SPRING;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class Issue394Test {
 

--- a/src/test/java/com/cronutils/Issue403Test.java
+++ b/src/test/java/com/cronutils/Issue403Test.java
@@ -6,8 +6,8 @@ import com.cronutils.model.definition.CronDefinition;
 import com.cronutils.model.definition.CronDefinitionBuilder;
 import com.cronutils.model.time.ExecutionTime;
 import com.cronutils.parser.CronParser;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
@@ -15,11 +15,11 @@ import java.time.format.DateTimeFormatter;
 import java.util.Locale;
 import java.util.Optional;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 
 public class Issue403Test {
-    @Ignore
+    @Disabled
     @Test
     public void testCase1() {
         CronParser parser = new CronParser( CronDefinitionBuilder.instanceDefinitionFor(CronType.QUARTZ));

--- a/src/test/java/com/cronutils/Issue404Test.java
+++ b/src/test/java/com/cronutils/Issue404Test.java
@@ -18,15 +18,15 @@ import com.cronutils.model.definition.CronDefinition;
 import com.cronutils.model.definition.CronDefinitionBuilder;
 import com.cronutils.model.time.ExecutionTime;
 import com.cronutils.parser.CronParser;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 import java.time.Duration;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * America/Sao_Paulo is only 3 hours behind UTC. Even with less difference, november 3 seems to be
@@ -34,7 +34,7 @@ import static org.junit.Assert.assertEquals;
  */
 public class Issue404Test {
 
-	@Ignore
+	@Disabled
 	@Test
 	public void testNovember3Midnight() {
 		final CronDefinition cronDefinition = CronDefinitionBuilder.defineCron().withMinutes().and().withHours().and()
@@ -51,7 +51,7 @@ public class Issue404Test {
 		assertEquals(1, timeFromLastExecution.getSeconds());
 	}
 
-	@Ignore
+	@Disabled
 	@Test
 	public void testNovember3Noon() {
 		final CronDefinition cronDefinition = CronDefinitionBuilder.defineCron().withMinutes().and().withHours().and()

--- a/src/test/java/com/cronutils/Issue404Test.java
+++ b/src/test/java/com/cronutils/Issue404Test.java
@@ -18,7 +18,6 @@ import com.cronutils.model.definition.CronDefinition;
 import com.cronutils.model.definition.CronDefinitionBuilder;
 import com.cronutils.model.time.ExecutionTime;
 import com.cronutils.parser.CronParser;
-import org.junit.Assert;
 import org.junit.Ignore;
 import org.junit.Test;
 
@@ -26,6 +25,8 @@ import java.time.Duration;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
+
+import static org.junit.Assert.assertEquals;
 
 /**
  * America/Sao_Paulo is only 3 hours behind UTC. Even with less difference, november 3 seems to be
@@ -47,7 +48,7 @@ public class Issue404Test {
 
 		final Duration timeFromLastExecution = executionTime.timeFromLastExecution(time).get();
 
-		Assert.assertEquals(1, timeFromLastExecution.getSeconds());
+		assertEquals(1, timeFromLastExecution.getSeconds());
 	}
 
 	@Ignore
@@ -64,7 +65,7 @@ public class Issue404Test {
 
 		final Duration timeFromLastExecution = executionTime.timeFromLastExecution(time).get();
 
-		Assert.assertEquals(12, timeFromLastExecution.toHours());
+		assertEquals(12, timeFromLastExecution.toHours());
 	}
 
 
@@ -81,7 +82,7 @@ public class Issue404Test {
 
 		final Duration timeFromLastExecution = executionTime.timeFromLastExecution(time).get();
 
-		Assert.assertEquals(1, timeFromLastExecution.getSeconds());
+		assertEquals(1, timeFromLastExecution.getSeconds());
 	}
 
 
@@ -98,6 +99,6 @@ public class Issue404Test {
 
 		final Duration timeFromLastExecution = executionTime.timeFromLastExecution(time).get();
 
-		Assert.assertEquals(16, timeFromLastExecution.toHours());
+		assertEquals(16, timeFromLastExecution.toHours());
 	}
 }

--- a/src/test/java/com/cronutils/Issue406Test.java
+++ b/src/test/java/com/cronutils/Issue406Test.java
@@ -5,7 +5,7 @@ import com.cronutils.model.definition.CronDefinition;
 import com.cronutils.model.definition.CronDefinitionBuilder;
 import com.cronutils.model.time.ExecutionTime;
 import com.cronutils.parser.CronParser;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.time.LocalDate;
 import java.time.LocalTime;
@@ -13,7 +13,7 @@ import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.util.Optional;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class Issue406Test {
     @Test

--- a/src/test/java/com/cronutils/Issue413Test.java
+++ b/src/test/java/com/cronutils/Issue413Test.java
@@ -3,9 +3,9 @@ package com.cronutils;
 import com.cronutils.model.CronType;
 import com.cronutils.model.definition.CronDefinitionBuilder;
 import com.cronutils.parser.CronParser;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class Issue413Test {
     @Test

--- a/src/test/java/com/cronutils/Issue418Test.java
+++ b/src/test/java/com/cronutils/Issue418Test.java
@@ -5,7 +5,6 @@ import com.cronutils.model.definition.CronDefinition;
 import com.cronutils.model.definition.CronDefinitionBuilder;
 import com.cronutils.model.time.ExecutionTime;
 import com.cronutils.parser.CronParser;
-import org.hamcrest.core.StringEndsWith;
 import org.junit.Test;
 
 import java.time.LocalDate;

--- a/src/test/java/com/cronutils/Issue418Test.java
+++ b/src/test/java/com/cronutils/Issue418Test.java
@@ -5,7 +5,7 @@ import com.cronutils.model.definition.CronDefinition;
 import com.cronutils.model.definition.CronDefinitionBuilder;
 import com.cronutils.model.time.ExecutionTime;
 import com.cronutils.parser.CronParser;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.time.LocalDate;
 import java.time.LocalTime;
@@ -13,8 +13,7 @@ import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.util.Optional;
 
-import static org.hamcrest.core.StringEndsWith.endsWith;
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class Issue418Test {
 
@@ -59,7 +58,7 @@ public class Issue418Test {
             parser.parse("0 0 2 ? * 0/7 *");
             fail("Expected exception for invalid expression");
         } catch (IllegalArgumentException expected) {
-            assertThat(expected.getMessage(), endsWith("Value 0 not in range [1, 7]"));
+            assertTrue(expected.getMessage().endsWith("Value 0 not in range [1, 7]"));
         }
     }
 
@@ -71,7 +70,7 @@ public class Issue418Test {
             parser.parse("0 0 2 ? * 1/8 *");
             fail("Expected exception for invalid expression");
         } catch (IllegalArgumentException expected) {
-            assertThat(expected.getMessage(), endsWith("Period 8 not in range [1, 7]"));
+            assertTrue(expected.getMessage().endsWith("Period 8 not in range [1, 7]"));
         }
     }
 }

--- a/src/test/java/com/cronutils/Issue421Test.java
+++ b/src/test/java/com/cronutils/Issue421Test.java
@@ -16,7 +16,6 @@ import java.util.Optional;
 import static com.cronutils.model.field.expression.FieldExpression.questionMark;
 import static com.cronutils.model.field.expression.FieldExpressionFactory.every;
 import static com.cronutils.model.field.expression.FieldExpressionFactory.on;
-import static junit.framework.TestCase.fail;
 import static org.junit.Assert.*;
 
 public class Issue421Test {

--- a/src/test/java/com/cronutils/Issue421Test.java
+++ b/src/test/java/com/cronutils/Issue421Test.java
@@ -7,7 +7,6 @@ import com.cronutils.model.definition.CronConstraintsFactory;
 import com.cronutils.model.definition.CronDefinition;
 import com.cronutils.model.definition.CronDefinitionBuilder;
 import com.cronutils.model.time.ExecutionTime;
-import org.junit.Assert;
 import org.junit.Test;
 
 import java.time.*;
@@ -18,6 +17,7 @@ import static com.cronutils.model.field.expression.FieldExpression.questionMark;
 import static com.cronutils.model.field.expression.FieldExpressionFactory.every;
 import static com.cronutils.model.field.expression.FieldExpressionFactory.on;
 import static junit.framework.TestCase.fail;
+import static org.junit.Assert.*;
 
 public class Issue421Test {
 
@@ -44,16 +44,16 @@ public class Issue421Test {
         ZonedDateTime nextRun;
 
         nextRun = nextRun(cron, now); // first run
-        Assert.assertEquals(2020, nextRun.getYear());
-        Assert.assertEquals(7, nextRun.getMonthValue());
+        assertEquals(2020, nextRun.getYear());
+        assertEquals(7, nextRun.getMonthValue());
 
         nextRun = nextRun(cron, nextRun); // first run
-        Assert.assertEquals(2020, nextRun.getYear());
-        Assert.assertEquals(12, nextRun.getMonthValue());
+        assertEquals(2020, nextRun.getYear());
+        assertEquals(12, nextRun.getMonthValue());
 
         nextRun = nextRun(cron, nextRun); // first run
-        Assert.assertEquals(2021, nextRun.getYear());
-        Assert.assertEquals(2, nextRun.getMonthValue());
+        assertEquals(2021, nextRun.getYear());
+        assertEquals(2, nextRun.getMonthValue());
     }
 
     @Test
@@ -67,16 +67,16 @@ public class Issue421Test {
         ZonedDateTime nextRun;
 
         nextRun = nextRun(cron, now); // first run
-        Assert.assertEquals(2020, nextRun.getYear());
-        Assert.assertEquals(6, nextRun.getMonthValue());
+        assertEquals(2020, nextRun.getYear());
+        assertEquals(6, nextRun.getMonthValue());
 
         nextRun = nextRun(cron, nextRun); // first run
-        Assert.assertEquals(2020, nextRun.getYear());
-        Assert.assertEquals(11, nextRun.getMonthValue());
+        assertEquals(2020, nextRun.getYear());
+        assertEquals(11, nextRun.getMonthValue());
 
         nextRun = nextRun(cron, nextRun); // first run
-        Assert.assertEquals(2021, nextRun.getYear());
-        Assert.assertEquals(1, nextRun.getMonthValue());
+        assertEquals(2021, nextRun.getYear());
+        assertEquals(1, nextRun.getMonthValue());
     }
 
     @Test
@@ -85,11 +85,11 @@ public class Issue421Test {
 
         String description = CronDescriptor.instance(Locale.US).describe(getEveryMonth(now, 3).instance());
         System.out.println(description);
-        Assert.assertTrue(description.contains("every 3 months"));
+        assertTrue(description.contains("every 3 months"));
 
         description = CronDescriptor.instance(Locale.US).describe(getEveryMonth(now, 6).instance());
         System.out.println(description);
-        Assert.assertTrue(description.contains("every 6 months"));
+        assertTrue(description.contains("every 6 months"));
     }
 
     public static CronBuilder getEveryMonth(ZonedDateTime now, int every) {

--- a/src/test/java/com/cronutils/Issue421Test.java
+++ b/src/test/java/com/cronutils/Issue421Test.java
@@ -7,7 +7,7 @@ import com.cronutils.model.definition.CronConstraintsFactory;
 import com.cronutils.model.definition.CronDefinition;
 import com.cronutils.model.definition.CronDefinitionBuilder;
 import com.cronutils.model.time.ExecutionTime;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.time.*;
 import java.util.Locale;
@@ -16,7 +16,7 @@ import java.util.Optional;
 import static com.cronutils.model.field.expression.FieldExpression.questionMark;
 import static com.cronutils.model.field.expression.FieldExpressionFactory.every;
 import static com.cronutils.model.field.expression.FieldExpressionFactory.on;
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class Issue421Test {
 

--- a/src/test/java/com/cronutils/Issue423Test.java
+++ b/src/test/java/com/cronutils/Issue423Test.java
@@ -6,8 +6,8 @@ import com.cronutils.model.CronType;
 import com.cronutils.model.definition.CronDefinitionBuilder;
 import com.cronutils.model.time.ExecutionTime;
 import com.cronutils.parser.CronParser;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 import java.time.LocalDate;
 import java.time.LocalTime;
@@ -16,9 +16,9 @@ import java.time.ZonedDateTime;
 import java.util.Arrays;
 import java.util.Locale;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-@Ignore
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+@Disabled
 public class Issue423Test {
     private static final LocalDate saturday = LocalDate.of(2020, 4, 25);
     private static ZonedDateTime shortZDT(int h, int m) {
@@ -61,9 +61,9 @@ public class Issue423Test {
         ).forEach(tp -> {
 //            System.err.println("Expected: " + tp.expected + "; Actual: " + et.nextExecution(tp.test).get().toString());
             assertEquals(
-                "All these should be on the same Saturday",
                 tp.expected,
-                et.nextExecution(tp.test).get()
+                et.nextExecution(tp.test).get(),
+                "All these should be on the same Saturday"
             );
         });
     }

--- a/src/test/java/com/cronutils/Issue430Test.java
+++ b/src/test/java/com/cronutils/Issue430Test.java
@@ -6,11 +6,12 @@ import com.cronutils.model.definition.CronDefinition;
 import com.cronutils.model.definition.CronDefinitionBuilder;
 import com.cronutils.model.time.ExecutionTime;
 import com.cronutils.parser.CronParser;
-import org.junit.Assert;
 import org.junit.Test;
 
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
+
+import static org.junit.Assert.*;
 
 public class Issue430Test {
     @Test
@@ -21,7 +22,7 @@ public class Issue430Test {
         ExecutionTime execution = ExecutionTime.forCron(cron);
         ZonedDateTime dateTime = ZonedDateTime.of(2020, 6, 30, 12, 0, 0, 0, ZoneOffset.UTC);
         // The cron starts from 2020, so no last execution date should be returned.
-        Assert.assertNull(execution.lastExecution(dateTime).orElse(null));
-        Assert.assertEquals(dateTime.plusYears(10), execution.nextExecution(dateTime).orElse(null));
+        assertNull(execution.lastExecution(dateTime).orElse(null));
+        assertEquals(dateTime.plusYears(10), execution.nextExecution(dateTime).orElse(null));
     }
 }

--- a/src/test/java/com/cronutils/Issue430Test.java
+++ b/src/test/java/com/cronutils/Issue430Test.java
@@ -6,12 +6,12 @@ import com.cronutils.model.definition.CronDefinition;
 import com.cronutils.model.definition.CronDefinitionBuilder;
 import com.cronutils.model.time.ExecutionTime;
 import com.cronutils.parser.CronParser;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class Issue430Test {
     @Test

--- a/src/test/java/com/cronutils/Issue430Test.java
+++ b/src/test/java/com/cronutils/Issue430Test.java
@@ -7,7 +7,6 @@ import com.cronutils.model.definition.CronDefinitionBuilder;
 import com.cronutils.model.time.ExecutionTime;
 import com.cronutils.parser.CronParser;
 import org.junit.Assert;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import java.time.ZoneOffset;

--- a/src/test/java/com/cronutils/Issue439Test.java
+++ b/src/test/java/com/cronutils/Issue439Test.java
@@ -4,18 +4,18 @@ import com.cronutils.descriptor.CronDescriptor;
 import com.cronutils.model.CronType;
 import com.cronutils.model.definition.CronDefinitionBuilder;
 import com.cronutils.parser.CronParser;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.Locale;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class Issue439Test {
 
 	private CronParser parser;
 
-	@Before
+	@BeforeEach
 	public void setUp() {
 		parser = new CronParser(CronDefinitionBuilder.instanceDefinitionFor(CronType.QUARTZ));
 	}

--- a/src/test/java/com/cronutils/Issue440Test.java
+++ b/src/test/java/com/cronutils/Issue440Test.java
@@ -4,11 +4,11 @@ import com.cronutils.descriptor.CronDescriptor;
 import com.cronutils.model.CronType;
 import com.cronutils.model.definition.CronDefinitionBuilder;
 import com.cronutils.parser.CronParser;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Locale;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class Issue440Test {
 

--- a/src/test/java/com/cronutils/Issue444Test.java
+++ b/src/test/java/com/cronutils/Issue444Test.java
@@ -5,7 +5,7 @@ import com.cronutils.model.CronType;
 import com.cronutils.model.definition.CronDefinitionBuilder;
 import com.cronutils.model.time.ExecutionTime;
 import com.cronutils.parser.CronParser;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.time.Clock;
 import java.time.Instant;
@@ -13,7 +13,7 @@ import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.util.Optional;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class Issue444Test {
 

--- a/src/test/java/com/cronutils/Issue446Test.java
+++ b/src/test/java/com/cronutils/Issue446Test.java
@@ -6,7 +6,6 @@ import com.cronutils.model.definition.CronConstraintsFactory;
 import com.cronutils.model.definition.CronDefinition;
 import com.cronutils.model.definition.CronDefinitionBuilder;
 import com.cronutils.model.time.ExecutionTime;
-import org.junit.Assert;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -19,6 +18,7 @@ import static com.cronutils.model.field.expression.FieldExpression.questionMark;
 import static com.cronutils.model.field.expression.FieldExpressionFactory.every;
 import static com.cronutils.model.field.expression.FieldExpressionFactory.on;
 import static junit.framework.TestCase.fail;
+import static org.junit.Assert.assertEquals;
 
 
 public class Issue446Test {
@@ -44,13 +44,13 @@ public class Issue446Test {
         Cron cron = getEveryMonthFromNow(dayOfAprilInLocalTimezone, 6).instance();
 
         ZonedDateTime nextRun = nextRun(cron, dayOfAprilInLocalTimezone); // first run
-        Assert.assertEquals(2020, nextRun.getYear());
-        Assert.assertEquals(10, nextRun.getMonthValue());
+        assertEquals(2020, nextRun.getYear());
+        assertEquals(10, nextRun.getMonthValue());
 
         nextRun = nextRun(cron, nextRun); // second
         System.out.println(nextRun);
-        Assert.assertEquals(2021, nextRun.getYear());
-        Assert.assertEquals(4, nextRun.getMonthValue());
+        assertEquals(2021, nextRun.getYear());
+        assertEquals(4, nextRun.getMonthValue());
     }
 
     public static CronBuilder getEveryMonthFromNow(ZonedDateTime now, int every) {
@@ -75,30 +75,30 @@ public class Issue446Test {
         Cron cron = getEvery30Minute(daylightSaving2020InLocalTimezone).instance();
 
         ZonedDateTime nextRun = nextRun(cron, daylightSaving2020InLocalTimezone); // first run
-        Assert.assertEquals(40, nextRun.getMinute());
-        Assert.assertEquals(1, nextRun.getHour());
+        assertEquals(40, nextRun.getMinute());
+        assertEquals(1, nextRun.getHour());
         nextRun = nextRun(cron, nextRun); // second
-        Assert.assertEquals(10, nextRun.getMinute());
-        Assert.assertEquals(2, nextRun.getHour());
-        Assert.assertEquals(ZoneOffset.ofHours(2), nextRun.getOffset());
+        assertEquals(10, nextRun.getMinute());
+        assertEquals(2, nextRun.getHour());
+        assertEquals(ZoneOffset.ofHours(2), nextRun.getOffset());
         nextRun = nextRun(cron, nextRun); // second
-        Assert.assertEquals(40, nextRun.getMinute());
-        Assert.assertEquals(2, nextRun.getHour());
-        Assert.assertEquals(ZoneOffset.ofHours(2), nextRun.getOffset());
+        assertEquals(40, nextRun.getMinute());
+        assertEquals(2, nextRun.getHour());
+        assertEquals(ZoneOffset.ofHours(2), nextRun.getOffset());
         nextRun = nextRun(cron, nextRun); // second
-        Assert.assertEquals(10, nextRun.getMinute());
-        Assert.assertEquals(2, nextRun.getHour());
-        Assert.assertEquals(ZoneOffset.ofHours(1), nextRun.getOffset());
+        assertEquals(10, nextRun.getMinute());
+        assertEquals(2, nextRun.getHour());
+        assertEquals(ZoneOffset.ofHours(1), nextRun.getOffset());
         nextRun = nextRun(cron, nextRun); // second
-        Assert.assertEquals(40, nextRun.getMinute());
-        Assert.assertEquals(2, nextRun.getHour());
-        Assert.assertEquals(ZoneOffset.ofHours(1), nextRun.getOffset());
+        assertEquals(40, nextRun.getMinute());
+        assertEquals(2, nextRun.getHour());
+        assertEquals(ZoneOffset.ofHours(1), nextRun.getOffset());
         nextRun = nextRun(cron, nextRun); // second
-        Assert.assertEquals(10, nextRun.getMinute());
-        Assert.assertEquals(3, nextRun.getHour());
+        assertEquals(10, nextRun.getMinute());
+        assertEquals(3, nextRun.getHour());
         nextRun = nextRun(cron, nextRun); // second
-        Assert.assertEquals(40, nextRun.getMinute());
-        Assert.assertEquals(3, nextRun.getHour());
+        assertEquals(40, nextRun.getMinute());
+        assertEquals(3, nextRun.getHour());
 
     }
 
@@ -111,13 +111,13 @@ public class Issue446Test {
         Cron cron = getEveryHour(daylightSaving2020InLocalTimezone).instance();
 
         ZonedDateTime nextRun = nextRun(cron, daylightSaving2020InLocalTimezone);
-        Assert.assertEquals(0, nextRun.getMinute());
-        Assert.assertEquals(2, nextRun.getHour());
-        Assert.assertEquals(ZoneOffset.ofHours(2), nextRun.getOffset());
+        assertEquals(0, nextRun.getMinute());
+        assertEquals(2, nextRun.getHour());
+        assertEquals(ZoneOffset.ofHours(2), nextRun.getOffset());
         nextRun = nextRun(cron, nextRun); // second
-        Assert.assertEquals(0, nextRun.getMinute());
-        Assert.assertEquals(3, nextRun.getHour());
-        Assert.assertEquals(ZoneOffset.ofHours(2), nextRun.getOffset());
+        assertEquals(0, nextRun.getMinute());
+        assertEquals(3, nextRun.getHour());
+        assertEquals(ZoneOffset.ofHours(2), nextRun.getOffset());
 
         startDay = LocalDateTime.of(2020, 10, 25, 1, 0); // Daylight saving
         clock = Clock.fixed(startDay.toInstant(ZoneOffset.ofHours(2)), ZoneId.of("Europe/Rome"));
@@ -126,17 +126,17 @@ public class Issue446Test {
         cron = getEveryHour(daylightSaving2020InLocalTimezone).instance();
 
         nextRun = nextRun(cron, daylightSaving2020InLocalTimezone); // first run
-        Assert.assertEquals(0, nextRun.getMinute());
-        Assert.assertEquals(2, nextRun.getHour());
-        Assert.assertEquals(ZoneOffset.ofHours(2), nextRun.getOffset());
+        assertEquals(0, nextRun.getMinute());
+        assertEquals(2, nextRun.getHour());
+        assertEquals(ZoneOffset.ofHours(2), nextRun.getOffset());
         nextRun = nextRun(cron, nextRun); // second
-        Assert.assertEquals(0, nextRun.getMinute());
-        Assert.assertEquals(2, nextRun.getHour());
-        Assert.assertEquals(ZoneOffset.ofHours(1), nextRun.getOffset());
+        assertEquals(0, nextRun.getMinute());
+        assertEquals(2, nextRun.getHour());
+        assertEquals(ZoneOffset.ofHours(1), nextRun.getOffset());
         nextRun = nextRun(cron, nextRun); // second
-        Assert.assertEquals(0, nextRun.getMinute());
-        Assert.assertEquals(3, nextRun.getHour());
-        Assert.assertEquals(ZoneOffset.ofHours(1), nextRun.getOffset());
+        assertEquals(0, nextRun.getMinute());
+        assertEquals(3, nextRun.getHour());
+        assertEquals(ZoneOffset.ofHours(1), nextRun.getOffset());
 
     }
 

--- a/src/test/java/com/cronutils/Issue446Test.java
+++ b/src/test/java/com/cronutils/Issue446Test.java
@@ -6,7 +6,7 @@ import com.cronutils.model.definition.CronConstraintsFactory;
 import com.cronutils.model.definition.CronDefinition;
 import com.cronutils.model.definition.CronDefinitionBuilder;
 import com.cronutils.model.time.ExecutionTime;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -17,7 +17,7 @@ import static com.cronutils.model.field.expression.FieldExpression.always;
 import static com.cronutils.model.field.expression.FieldExpression.questionMark;
 import static com.cronutils.model.field.expression.FieldExpressionFactory.every;
 import static com.cronutils.model.field.expression.FieldExpressionFactory.on;
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 
 public class Issue446Test {

--- a/src/test/java/com/cronutils/Issue446Test.java
+++ b/src/test/java/com/cronutils/Issue446Test.java
@@ -17,8 +17,7 @@ import static com.cronutils.model.field.expression.FieldExpression.always;
 import static com.cronutils.model.field.expression.FieldExpression.questionMark;
 import static com.cronutils.model.field.expression.FieldExpressionFactory.every;
 import static com.cronutils.model.field.expression.FieldExpressionFactory.on;
-import static junit.framework.TestCase.fail;
-import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.*;
 
 
 public class Issue446Test {

--- a/src/test/java/com/cronutils/Issue459Test.java
+++ b/src/test/java/com/cronutils/Issue459Test.java
@@ -2,21 +2,22 @@ package com.cronutils;
 
 import com.cronutils.builder.CronBuilder;
 import com.cronutils.model.definition.CronDefinitionBuilder;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static com.cronutils.model.CronType.UNIX;
 import static com.cronutils.model.field.expression.FieldExpression.always;
 import static com.cronutils.model.field.expression.FieldExpressionFactory.on;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class Issue459Test {
-    @Test(expected = RuntimeException.class)
+    @Test
     public void testNegativeValuesNotAllowed() {
-        CronBuilder.cron(CronDefinitionBuilder.instanceDefinitionFor(UNIX))
+        assertThrows(RuntimeException.class, () -> CronBuilder.cron(CronDefinitionBuilder.instanceDefinitionFor(UNIX))
                 .withDoM(always())
                 .withMonth(always())
                 .withDoW(always())
                 .withHour(on(-1))
                 .withMinute(on(5))
-                .instance();
+                .instance());
     }
 }

--- a/src/test/java/com/cronutils/Issue462Test.java
+++ b/src/test/java/com/cronutils/Issue462Test.java
@@ -13,15 +13,15 @@
 
 package com.cronutils;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import com.cronutils.descriptor.CronDescriptor;
 import com.cronutils.model.Cron;
 import com.cronutils.model.CronType;
 import com.cronutils.model.definition.CronDefinitionBuilder;
 import com.cronutils.parser.CronParser;
 import java.util.Locale;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Provide an example on how convert a cron expression to ISO8601
@@ -31,7 +31,7 @@ public class Issue462Test {
     private CronParser parser;
     private CronDescriptor descriptor;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         parser = new CronParser(CronDefinitionBuilder.instanceDefinitionFor(CronType.SPRING));
         descriptor = CronDescriptor.instance(Locale.ENGLISH);

--- a/src/test/java/com/cronutils/Issue462Test.java
+++ b/src/test/java/com/cronutils/Issue462Test.java
@@ -19,10 +19,8 @@ import com.cronutils.model.Cron;
 import com.cronutils.model.CronType;
 import com.cronutils.model.definition.CronDefinitionBuilder;
 import com.cronutils.parser.CronParser;
-import java.text.ParseException;
 import java.util.Locale;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 
 /**

--- a/src/test/java/com/cronutils/Issue470Test.java
+++ b/src/test/java/com/cronutils/Issue470Test.java
@@ -4,7 +4,7 @@ import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.util.Optional;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.cronutils.model.Cron;
 import com.cronutils.model.CronType;

--- a/src/test/java/com/cronutils/Issue470Test.java
+++ b/src/test/java/com/cronutils/Issue470Test.java
@@ -4,7 +4,6 @@ import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.util.Optional;
 
-import org.junit.Ignore;
 import org.junit.Test;
 
 import com.cronutils.model.Cron;

--- a/src/test/java/com/cronutils/Issue477Test.java
+++ b/src/test/java/com/cronutils/Issue477Test.java
@@ -1,10 +1,10 @@
 package com.cronutils;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.Locale;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.cronutils.descriptor.CronDescriptor;
 import com.cronutils.model.CronType;

--- a/src/test/java/com/cronutils/Issue480Test.java
+++ b/src/test/java/com/cronutils/Issue480Test.java
@@ -6,7 +6,6 @@ import com.cronutils.model.definition.CronConstraintsFactory;
 import com.cronutils.model.definition.CronDefinition;
 import com.cronutils.model.definition.CronDefinitionBuilder;
 import com.cronutils.model.time.ExecutionTime;
-import org.junit.Assert;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -20,6 +19,7 @@ import static com.cronutils.model.field.expression.FieldExpressionFactory.always
 import static com.cronutils.model.field.expression.FieldExpressionFactory.on;
 import static junit.framework.Assert.assertTrue;
 import static junit.framework.TestCase.fail;
+import static org.junit.Assert.assertEquals;
 
 public class Issue480Test {
 
@@ -41,7 +41,7 @@ public class Issue480Test {
     @Test
     public void testIntervalsEvery5thMonthsSinceASpecificMonth() {
         LocalDateTime sunday = LocalDateTime.of(2021, 6, 27, 0, 0);
-        Assert.assertEquals(sunday.getDayOfWeek(), DayOfWeek.SUNDAY);
+        assertEquals(sunday.getDayOfWeek(), DayOfWeek.SUNDAY);
         Clock clock = Clock.fixed(sunday.toInstant(ZoneOffset.UTC), ZoneId.systemDefault());
         ZonedDateTime now = ZonedDateTime.now(clock);
         LOGGER.info("Now: {}", now);

--- a/src/test/java/com/cronutils/Issue480Test.java
+++ b/src/test/java/com/cronutils/Issue480Test.java
@@ -17,9 +17,7 @@ import java.util.Optional;
 import static com.cronutils.model.field.expression.FieldExpression.questionMark;
 import static com.cronutils.model.field.expression.FieldExpressionFactory.always;
 import static com.cronutils.model.field.expression.FieldExpressionFactory.on;
-import static junit.framework.Assert.assertTrue;
-import static junit.framework.TestCase.fail;
-import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.*;
 
 public class Issue480Test {
 

--- a/src/test/java/com/cronutils/Issue480Test.java
+++ b/src/test/java/com/cronutils/Issue480Test.java
@@ -7,7 +7,6 @@ import com.cronutils.model.definition.CronDefinition;
 import com.cronutils.model.definition.CronDefinitionBuilder;
 import com.cronutils.model.time.ExecutionTime;
 import org.junit.Assert;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/src/test/java/com/cronutils/Issue480Test.java
+++ b/src/test/java/com/cronutils/Issue480Test.java
@@ -6,7 +6,7 @@ import com.cronutils.model.definition.CronConstraintsFactory;
 import com.cronutils.model.definition.CronDefinition;
 import com.cronutils.model.definition.CronDefinitionBuilder;
 import com.cronutils.model.time.ExecutionTime;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -17,7 +17,7 @@ import java.util.Optional;
 import static com.cronutils.model.field.expression.FieldExpression.questionMark;
 import static com.cronutils.model.field.expression.FieldExpressionFactory.always;
 import static com.cronutils.model.field.expression.FieldExpressionFactory.on;
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class Issue480Test {
 

--- a/src/test/java/com/cronutils/Issue499Test.java
+++ b/src/test/java/com/cronutils/Issue499Test.java
@@ -1,34 +1,26 @@
 package com.cronutils;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
-import com.cronutils.mapper.CronMapper;
-import com.cronutils.model.Cron;
 import com.cronutils.model.CronType;
 import com.cronutils.model.definition.CronDefinitionBuilder;
 import com.cronutils.parser.CronParser;
 
-import org.junit.jupiter.api.Disabled;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 class Issue499Test {
     /**
-     * We want to convert Unix cron expressions to Quartz cron expressions. We 
+     * We want to convert Unix cron expressions to Quartz cron expressions. We
      * expect an exception: java.lang.IllegalArgumentException:
      * Failed to parse '12 1 * ? *'. Invalid expression: ?
-     * Given question marks are not supported at Unix crons. See: 
+     * Given question marks are not supported at Unix crons. See:
      * https://github.com/jmrozanec/cron-utils/issues/499
      */
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     void testCronExpressionForConversionToQuartz() {
         final CronParser unixParser = new CronParser(CronDefinitionBuilder.instanceDefinitionFor(CronType.UNIX));
-        final CronMapper unixToQuartz = CronMapper.fromUnixToQuartz();
         final String unixExpression = "12 1 * ? *";
         // Works on 5.0.5, throws IllegalArgumentException in 9.1.3
-        final Cron unixCron = unixParser.parse(unixExpression);
-        // Goal: Convert unix expressions to quartz.
-        final String quartzExpression = unixToQuartz.map(unixCron).asString();
-        // This is what we expected.
-        assertEquals("0 12 1 * ? ? *", quartzExpression);
+        assertThrows(IllegalArgumentException.class, () -> unixParser.parse(unixExpression));
     }
 }

--- a/src/test/java/com/cronutils/Issue528Test.java
+++ b/src/test/java/com/cronutils/Issue528Test.java
@@ -7,7 +7,7 @@ import com.cronutils.model.definition.CronDefinition;
 import com.cronutils.model.definition.CronDefinitionBuilder;
 import com.cronutils.model.time.ExecutionTime;
 import com.cronutils.parser.CronParser;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Assertions;
 
 import java.time.ZonedDateTime;
@@ -49,7 +49,7 @@ public class Issue528Test {
         Assertions.assertEquals(cron.asString(), mapped.asString());
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testCronMapperRebootNotSupportedOnTarget() {
         Cron cron = new CronParser(REBOOT_CRON_DEFINITION).parse("@reboot");
         CronDefinition unix = CronDefinitionBuilder.defineCron()
@@ -59,7 +59,6 @@ public class Issue528Test {
                 .withMonth().withValidRange(1, 12).withStrictRange().and()
                 .withDayOfWeek().withValidRange(0, 7).withMondayDoWValue(1).withIntMapping(7, 0).withStrictRange().and()
                 .instance();
-        Cron mapped = CronMapper.sameCron(unix).map(cron);
-        Assertions.assertEquals(cron.asString(), mapped.asString());
+        Assertions.assertThrows(IllegalArgumentException.class, () -> CronMapper.sameCron(unix).map(cron));
     }
 }

--- a/src/test/java/com/cronutils/Issue55UnexpectedExecutionTimes.java
+++ b/src/test/java/com/cronutils/Issue55UnexpectedExecutionTimes.java
@@ -21,8 +21,8 @@ import com.cronutils.model.field.CronFieldName;
 import com.cronutils.model.field.expression.QuestionMark;
 import com.cronutils.model.time.ExecutionTime;
 import com.cronutils.parser.CronParser;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -33,7 +33,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class Issue55UnexpectedExecutionTimes {
 
@@ -43,7 +43,7 @@ public class Issue55UnexpectedExecutionTimes {
     /**
      * Setup.
      */
-    @Before
+    @BeforeEach
     public void setUp() {
         cronDefinition = CronDefinitionBuilder.defineCron()
                 .withMinutes().and()

--- a/src/test/java/com/cronutils/Issue58UnixCronAsStringIntegrationTest.java
+++ b/src/test/java/com/cronutils/Issue58UnixCronAsStringIntegrationTest.java
@@ -18,17 +18,18 @@ import com.cronutils.model.CronType;
 import com.cronutils.model.definition.CronDefinition;
 import com.cronutils.model.definition.CronDefinitionBuilder;
 import com.cronutils.parser.CronParser;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-import static org.hamcrest.core.AnyOf.anyOf;
-import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertThat;
+import java.util.Arrays;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class Issue58UnixCronAsStringIntegrationTest {
     private CronParser cronParser;
 
-    @Before
+    @BeforeEach
     public void setup() {
         final CronDefinition cronDefinition = CronDefinitionBuilder.instanceDefinitionFor(CronType.UNIX);
         cronParser = new CronParser(cronDefinition);
@@ -37,24 +38,24 @@ public class Issue58UnixCronAsStringIntegrationTest {
     @Test
     public void everyEvenHourShouldBeParsedCorrectly() {
         final Cron cron = cronParser.parse("0 0/1 * * *");
-        assertThat(cron.asString(), anyOf(is("0 0/1 * * *"), is("0 /1 * * *"), is("0 0 * * *")));
+        assertTrue(Arrays.asList("0 0/1 * * *","0 /1 * * *","0 0 * * *").contains(cron.asString()));
     }
 
     @Test
     public void everyOddHourShouldBeParsedCorrectly() {
         final Cron cron = cronParser.parse("0 1/2 * * *");
-        assertThat(cron.asString(), is("0 1/2 * * *"));
+        assertEquals("0 1/2 * * *", cron.asString());
     }
 
     @Test
     public void everyEvenMinuteShouldBeParsedCorrectly() {
         final Cron cron = cronParser.parse("0/1 * * * *");
-        assertThat(cron.asString(), anyOf(is("0/1 * * * *"), is("/1 * * * *"), is("0 * * * *")));
+        assertTrue(Arrays.asList("0/1 * * * *", "/1 * * * *", "0 * * * *").contains(cron.asString()));
     }
 
     @Test
     public void everyOddMinuteShouldBeParsedCorrectly() {
         final Cron cron = cronParser.parse("1/2 * * * *");
-        assertThat(cron.asString(), is("1/2 * * * *"));
+        assertEquals("1/2 * * * *", cron.asString());
     }
 }

--- a/src/test/java/com/cronutils/OpenIssuesTest.java
+++ b/src/test/java/com/cronutils/OpenIssuesTest.java
@@ -18,7 +18,7 @@ import com.cronutils.model.CronType;
 import com.cronutils.model.definition.CronDefinitionBuilder;
 import com.cronutils.model.time.ExecutionTime;
 import com.cronutils.parser.CronParser;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;

--- a/src/test/java/com/cronutils/converter/CronConverterTest.java
+++ b/src/test/java/com/cronutils/converter/CronConverterTest.java
@@ -14,7 +14,6 @@
 package com.cronutils.converter;
 
 import org.junit.Assert;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;

--- a/src/test/java/com/cronutils/converter/CronConverterTest.java
+++ b/src/test/java/com/cronutils/converter/CronConverterTest.java
@@ -13,48 +13,41 @@
 
 package com.cronutils.converter;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.time.ZoneId;
-import java.util.Arrays;
-import java.util.Collection;
+import java.util.stream.Stream;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.spy;
 
-@RunWith(Parameterized.class)
 public class CronConverterTest {
-
-	private String timezone;
-	private String inputCronExpression;
-	private String expectedCronExpression;
 	private CronConverter cronConverter = spy(new CronConverter(
 			new CronToCalendarTransformer(),
 			new CalendarToCronTransformer()
 	));
 
-	public CronConverterTest(String timezone, String inputCronExpression, String expectedCronExpression) {
-		this.timezone = timezone;
-		this.inputCronExpression = inputCronExpression;
-		this.expectedCronExpression = expectedCronExpression;
+	public static Stream<Arguments> cronExpressions() {
+		return Stream.of(Arguments.of("Pacific/Pago_Pago", "15 * * * *", "15 * * * *"),
+				Arguments.of("Antarctica/Casey", "? * * * *", "? * * * *"),
+				Arguments.of("Antarctica/Troll", "45 * * * *", "45 * * * *"),
+				Arguments.of("Pacific/Chatham", "15 * * * *", "30 * * * *"),
+				Arguments.of("Asia/Colombo", "45 * * ? *", "15 * * ? *"),
+				Arguments.of("Asia/Colombo", "0/45 * * ? *", "0/45 * * ? *"),
+				Arguments.of("Australia/Eucla", "13 * * ? *", "28 * * ? *"),
+				Arguments.of("America/St_Johns", "0 0/15 * * * ?", "30 0/15 * * * ?"),
+				Arguments.of("America/St_Johns", "0 8 * * ?", "30 10 * * ?"),
+				Arguments.of("America/St_Johns", "0 0/1 * * ?", "30 0/1 * * ?"),
+				Arguments.of("America/St_Johns", "20 0 * * ?", "50 2 * * ?"),
+				Arguments.of("Asia/Kolkata", "20 0 * * ?", "50 18 * * ?")
+		);
 	}
 
-	@Parameterized.Parameters
-	public static Collection cronExpressions() {
-		return Arrays.asList(new Object[][] { { "Pacific/Pago_Pago", "15 * * * *", "15 * * * *" },
-				{ "Antarctica/Casey", "? * * * *", "? * * * *" }, { "Antarctica/Troll", "45 * * * *", "45 * * * *" },
-				{ "Pacific/Chatham", "15 * * * *", "30 * * * *" }, { "Asia/Colombo", "45 * * ? *", "15 * * ? *" },
-				{ "Asia/Colombo", "0/45 * * ? *", "0/45 * * ? *" }, { "Australia/Eucla", "13 * * ? *", "28 * * ? *" },
-				{ "America/St_Johns", "0 0/15 * * * ?", "30 0/15 * * * ?" },
-				{ "America/St_Johns", "0 8 * * ?", "30 10 * * ?" },
-				{ "America/St_Johns", "0 0/1 * * ?", "30 0/1 * * ?" },
-				{ "America/St_Johns", "20 0 * * ?", "50 2 * * ?" }, { "Asia/Kolkata", "20 0 * * ?", "50 18 * * ?" }, });
-	}
-
-	@Test
-	public void testCronConverterBuilder() {
+	@ParameterizedTest
+	@MethodSource("cronExpressions")
+	public void testCronConverterBuilder(String timezone, String inputCronExpression, String expectedCronExpression) {
 		assertEquals(expectedCronExpression,
 				cronConverter.using(inputCronExpression)
 						.from(ZoneId.of(timezone)).to(ZoneId.of("UTC"))

--- a/src/test/java/com/cronutils/converter/CronConverterTest.java
+++ b/src/test/java/com/cronutils/converter/CronConverterTest.java
@@ -13,7 +13,6 @@
 
 package com.cronutils.converter;
 
-import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -22,6 +21,7 @@ import java.time.ZoneId;
 import java.util.Arrays;
 import java.util.Collection;
 
+import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.spy;
 
 @RunWith(Parameterized.class)
@@ -55,7 +55,7 @@ public class CronConverterTest {
 
 	@Test
 	public void testCronConverterBuilder() {
-		Assert.assertEquals(expectedCronExpression,
+		assertEquals(expectedCronExpression,
 				cronConverter.using(inputCronExpression)
 						.from(ZoneId.of(timezone)).to(ZoneId.of("UTC"))
 						.convert());

--- a/src/test/java/com/cronutils/mapper/ConstantsMapperTest.java
+++ b/src/test/java/com/cronutils/mapper/ConstantsMapperTest.java
@@ -13,9 +13,9 @@
 
 package com.cronutils.mapper;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class ConstantsMapperTest {
 

--- a/src/test/java/com/cronutils/mapper/CronMapperIntegrationTest.java
+++ b/src/test/java/com/cronutils/mapper/CronMapperIntegrationTest.java
@@ -16,12 +16,12 @@ package com.cronutils.mapper;
 import com.cronutils.model.CronType;
 import com.cronutils.model.definition.CronDefinitionBuilder;
 import com.cronutils.parser.CronParser;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class CronMapperIntegrationTest {
 
@@ -86,8 +86,8 @@ public class CronMapperIntegrationTest {
         final String expected2 = "0 * * ? * * *";
         final String mapping = CronMapper.fromUnixToQuartz().map(unixParser().parse(input)).asString();
         assertTrue(
-                String.format("Expected [%s] or [%s] but got [%s]", expected1, expected2, mapping),
-                Arrays.asList(expected1, expected2).contains(mapping)
+                Arrays.asList(expected1, expected2).contains(mapping),
+                String.format("Expected [%s] or [%s] but got [%s]", expected1, expected2, mapping)
         );
     }
 
@@ -100,7 +100,7 @@ public class CronMapperIntegrationTest {
         final String input = "0 0 * * 1";
         final String expected = "0 0 0 ? * 2 *";
         final String mapping = CronMapper.fromUnixToQuartz().map(unixParser().parse(input)).asString();
-        assertEquals(String.format("Expected [%s] but got [%s]", expected, mapping), expected, mapping);
+        assertEquals(expected, mapping, String.format("Expected [%s] but got [%s]", expected, mapping));
     }
 
     private CronParser cron4jParser() {

--- a/src/test/java/com/cronutils/mapper/CronMapperTest.java
+++ b/src/test/java/com/cronutils/mapper/CronMapperTest.java
@@ -19,12 +19,13 @@ import com.cronutils.model.field.CronField;
 import com.cronutils.model.field.CronFieldName;
 import com.cronutils.model.field.expression.Always;
 import com.cronutils.model.field.expression.On;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 
 public class CronMapperTest {
@@ -32,20 +33,20 @@ public class CronMapperTest {
     @Mock
     private CronField mockCronField;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         MockitoAnnotations.initMocks(this);
         testCronFieldName = CronFieldName.SECOND;
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void testConstructorSourceDefinitionNull() {
-        new CronMapper(mock(CronDefinition.class), null, null);
+        assertThrows(NullPointerException.class, () -> new CronMapper(mock(CronDefinition.class), null, null));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void testConstructorTargetDefinitionNull() {
-        new CronMapper(null, mock(CronDefinition.class), null);
+        assertThrows(NullPointerException.class, () -> new CronMapper(null, mock(CronDefinition.class), null));
     }
 
     @Test

--- a/src/test/java/com/cronutils/mapper/MappingOptionalFieldsTest.java
+++ b/src/test/java/com/cronutils/mapper/MappingOptionalFieldsTest.java
@@ -17,9 +17,9 @@ import com.cronutils.model.CronType;
 import com.cronutils.model.definition.CronDefinition;
 import com.cronutils.model.definition.CronDefinitionBuilder;
 import com.cronutils.parser.CronParser;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class MappingOptionalFieldsTest {
 
@@ -43,7 +43,7 @@ public class MappingOptionalFieldsTest {
         final String expected = "0 9-18 * * 0-2";
         final String expression = "5 0 9-18 ? * 1-3";
         final String mapping = mapper.map(parser.parse(expression)).asString();
-        assertEquals(String.format("Expected [%s] but got [%s]", expected, mapping), expected, mapping);
+        assertEquals(expected, mapping, String.format("Expected [%s] but got [%s]", expected, mapping));
     }
 
 }

--- a/src/test/java/com/cronutils/mapper/WeekDayTest.java
+++ b/src/test/java/com/cronutils/mapper/WeekDayTest.java
@@ -13,10 +13,11 @@
 
 package com.cronutils.mapper;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 
 public class WeekDayTest {
@@ -24,14 +25,14 @@ public class WeekDayTest {
     private static final int MONDAY_DOW_VALUE = 1;
     private static final boolean IS_FIRST_DAY_ZERO = false;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         source = new WeekDay(MONDAY_DOW_VALUE, IS_FIRST_DAY_ZERO);
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testConstructorFailsIfMondayDoWNegative() {
-        new WeekDay(-1, IS_FIRST_DAY_ZERO);
+        assertThrows(IllegalArgumentException.class, () -> new WeekDay(-1, IS_FIRST_DAY_ZERO));
     }
 
     @Test

--- a/src/test/java/com/cronutils/model/CompositeCronTest.java
+++ b/src/test/java/com/cronutils/model/CompositeCronTest.java
@@ -47,7 +47,7 @@ public class CompositeCronTest {
         CronParser parser2 = new CronParser(definition2);
 
         Cron cron1 = parser.parse("0 0 0 15 8 ? 2015/2");
-        Cron cron2 = parser2.parse("0 0 0 * *");
+        Cron cron2 = parser2.parse("0 0 1 * *");
         List<Cron> crons = new ArrayList<>();
         crons.add(cron1);
         crons.add(cron2);

--- a/src/test/java/com/cronutils/model/CompositeCronTest.java
+++ b/src/test/java/com/cronutils/model/CompositeCronTest.java
@@ -6,15 +6,15 @@ import com.cronutils.model.definition.CronDefinitionBuilder;
 import com.cronutils.model.field.CronFieldName;
 import com.cronutils.model.time.ExecutionTime;
 import com.cronutils.parser.CronParser;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
 import static java.time.ZoneOffset.UTC;
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.mock;
 
 public class CompositeCronTest {
@@ -22,7 +22,7 @@ public class CompositeCronTest {
     private Cron cron1;
     private Cron cron2;
 
-    @Before
+    @BeforeEach
     public void setUp(){
         definition1 = CronDefinitionBuilder.instanceDefinitionFor(CronType.QUARTZ);
         CronParser parser = new CronParser(definition1);
@@ -40,7 +40,7 @@ public class CompositeCronTest {
         this.cron2 = new CompositeCron(crons2);
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void weDoNotSupportCronsWithDifferentDefinitions() throws Exception {
         CronDefinition definition2 = CronDefinitionBuilder.instanceDefinitionFor(CronType.UNIX);
         CronParser parser = new CronParser(definition1);
@@ -51,22 +51,22 @@ public class CompositeCronTest {
         List<Cron> crons = new ArrayList<>();
         crons.add(cron1);
         crons.add(cron2);
-        new CompositeCron(crons);
+        assertThrows(IllegalArgumentException.class, () -> new CompositeCron(crons));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void weDoNotSupportCompositeWithoutCrons() throws Exception {
-        new CompositeCron(new ArrayList<>());
+        assertThrows(IllegalArgumentException.class, () -> new CompositeCron(new ArrayList<>()));
     }
 
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void retrieve() throws Exception {
-        cron1.retrieve(CronFieldName.DAY_OF_WEEK);
+        assertThrows(UnsupportedOperationException.class, () -> cron1.retrieve(CronFieldName.DAY_OF_WEEK));
     }
 
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void retrieveFieldsAsMap() throws Exception {
-        cron1.retrieveFieldsAsMap();
+        assertThrows(UnsupportedOperationException.class, () -> cron1.retrieveFieldsAsMap());
     }
 
     @Test
@@ -84,14 +84,14 @@ public class CompositeCronTest {
         cron1.validate();
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void validateThrowsExceptionEmptyCrons(){
-        new CompositeCron(new ArrayList<>());
+        assertThrows(IllegalArgumentException.class, () -> new CompositeCron(new ArrayList<>()));
     }
 
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void equivalent() throws Exception {
-        cron1.equivalent(CronMapper.fromQuartzToCron4j(), mock(Cron.class));
+        assertThrows(UnsupportedOperationException.class, () -> cron1.equivalent(CronMapper.fromQuartzToCron4j(), mock(Cron.class)));
     }
 
     @Test

--- a/src/test/java/com/cronutils/model/CronTest.java
+++ b/src/test/java/com/cronutils/model/CronTest.java
@@ -20,8 +20,8 @@ import com.cronutils.model.field.CronField;
 import com.cronutils.model.field.CronFieldName;
 import com.cronutils.model.field.expression.FieldExpression;
 import com.cronutils.parser.CronParser;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
@@ -29,7 +29,7 @@ import java.io.*;
 import java.util.Collections;
 import java.util.List;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -40,7 +40,7 @@ public class CronTest {
     @Mock
     private CronField mockField;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         MockitoAnnotations.initMocks(this);
         testName = CronFieldName.SECOND;
@@ -49,14 +49,14 @@ public class CronTest {
         cron = new SingleCron(mock(CronDefinition.class), fields);
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void testConstructorNullFieldsParameter() {
-        new SingleCron(mock(CronDefinition.class), null);
+        assertThrows(NullPointerException.class, () -> new SingleCron(mock(CronDefinition.class), null));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void testConstructorNullDefinitionParameter() {
-        new SingleCron(null, fields);
+        assertThrows(NullPointerException.class, () -> new SingleCron(null, fields));
     }
 
     @Test
@@ -64,9 +64,9 @@ public class CronTest {
         assertEquals(mockField, cron.retrieve(testName));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void testRetrieveNullParameter() {
-        cron.retrieve(null);
+        assertThrows(NullPointerException.class, () -> cron.retrieve(null));
     }
 
     @Test

--- a/src/test/java/com/cronutils/model/ExecutionDatesTest.java
+++ b/src/test/java/com/cronutils/model/ExecutionDatesTest.java
@@ -3,8 +3,8 @@ package com.cronutils.model;
 import com.cronutils.model.definition.CronDefinitionBuilder;
 import com.cronutils.model.time.ExecutionTime;
 import com.cronutils.parser.CronParser;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
@@ -16,7 +16,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 public class ExecutionDatesTest {
     private CronParser cron4jCronParser;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         cron4jCronParser = new CronParser(CronDefinitionBuilder.instanceDefinitionFor(CronType.CRON4J));
     }

--- a/src/test/java/com/cronutils/model/definition/CronDefinitionBuilderTest.java
+++ b/src/test/java/com/cronutils/model/definition/CronDefinitionBuilderTest.java
@@ -22,21 +22,22 @@ import com.cronutils.model.field.definition.FieldDefinition;
 import com.cronutils.model.field.expression.Weekdays;
 import com.cronutils.model.field.value.SpecialChar;
 import com.cronutils.parser.CronParser;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
 import java.util.Set;
 
 import static com.cronutils.model.field.expression.FieldExpressionFactory.*;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class CronDefinitionBuilderTest {
 
     private CronDefinitionBuilder builder;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         builder = CronDefinitionBuilder.defineCron();
     }
@@ -141,28 +142,27 @@ public class CronDefinitionBuilderTest {
         assertNotNull(CronDefinitionBuilder.instanceDefinitionFor(CronType.CRON4J));
     }
 
-    @Test(expected = RuntimeException.class)
+    @Test
     public void testInstanceDefinitionForUnknownValue() {
-        assertNotNull(CronDefinitionBuilder.instanceDefinitionFor(null));
+        assertThrows(RuntimeException.class, () -> assertNotNull(CronDefinitionBuilder.instanceDefinitionFor(null)));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testCronDefinitionShouldNotAcceptQuestionmark() {
         final CronDefinition cronDefinition = CronDefinitionBuilder.instanceDefinitionFor(CronType.UNIX);
         final CronParser parser = new CronParser(cronDefinition);
-        final Cron quartzCron = parser.parse("* * * * ?");
-        quartzCron.validate();
+        assertThrows(IllegalArgumentException.class, () -> parser.parse("* * * * ?"));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testCronDefinitionShouldNotAcceptMultipleOptionalFields() {
-        CronDefinitionBuilder.defineCron()
+        assertThrows(IllegalArgumentException.class, () -> CronDefinitionBuilder.defineCron()
                 .withMinutes().and()
                 .withHours().and()
                 .withDayOfMonth().optional().and()
                 .withMonth().optional().and()
                 .withDayOfWeek().withValidRange(0, 7).withMondayDoWValue(1).withIntMapping(7, 0).and()
-                .instance();
+                .instance());
     }
 
     /**

--- a/src/test/java/com/cronutils/model/definition/CronDefinitionIssue25IntegrationTest.java
+++ b/src/test/java/com/cronutils/model/definition/CronDefinitionIssue25IntegrationTest.java
@@ -17,16 +17,16 @@ import com.cronutils.model.Cron;
 import com.cronutils.model.field.CronFieldName;
 import com.cronutils.model.time.ExecutionTime;
 import com.cronutils.parser.CronParser;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class CronDefinitionIssue25IntegrationTest {
     private CronDefinition cronDefinition;
     static final String CRON_EXPRESSION = "0 18 1";
 
-    @Before
+    @BeforeEach
     public void setUp() {
         cronDefinition =
                 CronDefinitionBuilder.defineCron()

--- a/src/test/java/com/cronutils/model/definition/CronDefinitionTest.java
+++ b/src/test/java/com/cronutils/model/definition/CronDefinitionTest.java
@@ -17,11 +17,11 @@ import com.cronutils.model.CronType;
 import com.cronutils.model.field.CronFieldName;
 import com.cronutils.model.field.constraint.FieldConstraintsBuilder;
 import com.cronutils.model.field.definition.FieldDefinition;
-import junitparams.JUnitParamsRunner;
-import junitparams.Parameters;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
@@ -30,11 +30,11 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.function.UnaryOperator;
+import java.util.stream.Stream;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.when;
 
-@RunWith(JUnitParamsRunner.class)
 public class CronDefinitionTest {
 
     private boolean matchDayOfWeekAndDayOfMonth;
@@ -45,7 +45,7 @@ public class CronDefinitionTest {
     @Mock
     private FieldDefinition mockFieldDefinition3optional;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         final CronFieldName testFieldName1 = CronFieldName.SECOND;
         final CronFieldName testFieldName2 = CronFieldName.MINUTE;
@@ -59,24 +59,24 @@ public class CronDefinitionTest {
         matchDayOfWeekAndDayOfMonth = false;
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void testConstructorNullFieldsParameter() {
-        new CronDefinition(null, new HashSet<>(), new HashSet<>(), matchDayOfWeekAndDayOfMonth);
+        assertThrows(NullPointerException.class, () -> new CronDefinition(null, new HashSet<>(), new HashSet<>(), matchDayOfWeekAndDayOfMonth));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void testConstructorNullConstraintsParameter() {
-        new CronDefinition(new ArrayList<>(), null, new HashSet<>(), matchDayOfWeekAndDayOfMonth);
+        assertThrows(NullPointerException.class, () -> new CronDefinition(new ArrayList<>(), null, new HashSet<>(), matchDayOfWeekAndDayOfMonth));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void testConstructorNullCronNicknamesParameter() {
-        new CronDefinition(new ArrayList<>(), new HashSet<>(), null, matchDayOfWeekAndDayOfMonth);
+        assertThrows(NullPointerException.class, () -> new CronDefinition(new ArrayList<>(), new HashSet<>(), null, matchDayOfWeekAndDayOfMonth));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testConstructorEmptyFieldsParameter() {
-        new CronDefinition(new ArrayList<>(), new HashSet<>(), new HashSet<>(), matchDayOfWeekAndDayOfMonth);
+        assertThrows(IllegalArgumentException.class, () -> new CronDefinition(new ArrayList<>(), new HashSet<>(), new HashSet<>(), matchDayOfWeekAndDayOfMonth));
     }
 
     @Test
@@ -102,11 +102,11 @@ public class CronDefinitionTest {
         return definitions;
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testLastFieldOptionalNotAllowedOnSingleFieldDefinition() {
         final List<FieldDefinition> fields = new ArrayList<>();
         fields.add(mockFieldDefinition3optional);
-        new CronDefinition(fields, new HashSet<>(), new HashSet<>(), matchDayOfWeekAndDayOfMonth);
+        assertThrows(IllegalArgumentException.class, () -> new CronDefinition(fields, new HashSet<>(), new HashSet<>(), matchDayOfWeekAndDayOfMonth));
     }
 
     @Test
@@ -123,8 +123,8 @@ public class CronDefinitionTest {
         assertEquals(CronDefinitionBuilder.instanceDefinitionFor(CronType.QUARTZ), CronDefinitionBuilder.instanceDefinitionFor(CronType.QUARTZ));
     }
 
-    @Test
-    @Parameters(method = "parametersToTestIfEqual")
+    @ParameterizedTest
+    @MethodSource("parametersToTestIfEqual")
     public void testIfDefinitionsAreEqual(
         List<FieldDefinition> fieldDefinitionsOne,
         List<FieldDefinition> fieldDefinitionsTwo,
@@ -159,9 +159,9 @@ public class CronDefinitionTest {
     }
 
     @SuppressWarnings("unused")
-    private Object[] parametersToTestIfEqual() {
-        return new Object[] {
-            new Object[] {
+    private static Stream<Arguments> parametersToTestIfEqual() {
+        return Stream.of(
+            Arguments.of(
                 provideSimpleFieldDefinitions(),
                 provideSimpleFieldDefinitions(),
                 provideCronConstraintSetWithTwoConstraints(),
@@ -171,8 +171,8 @@ public class CronDefinitionTest {
                 true,
                 true,
                 true
-            },
-            new Object[] {
+            ),
+            Arguments.of(
                 provideFieldDefinitions(CronFieldName.SECOND, b -> b.withValidRange(0, 59)),
                 provideFieldDefinitions(CronFieldName.SECOND, b -> b.withValidRange(1, 60)),
                 provideCronConstraintSetWithTwoConstraints(),
@@ -182,8 +182,8 @@ public class CronDefinitionTest {
                 true,
                 true,
                 false
-            },
-            new Object[] {
+            ),
+            Arguments.of(
                 provideSimpleFieldDefinitions(),
                 provideSimpleFieldDefinitions(),
                 provideCronConstraintSetWithOneConstraint(),
@@ -193,8 +193,8 @@ public class CronDefinitionTest {
                 true,
                 true,
                 false
-            },
-            new Object[] {
+            ),
+            Arguments.of(
                 provideSimpleFieldDefinitions(),
                 provideSimpleFieldDefinitions(),
                 provideCronConstraintSetWithTwoConstraints(),
@@ -204,8 +204,8 @@ public class CronDefinitionTest {
                 true,
                 true,
                 false
-            },
-            new Object[] {
+            ),
+            Arguments.of(
                 provideSimpleFieldDefinitions(),
                 provideSimpleFieldDefinitions(),
                 provideCronConstraintSetWithTwoConstraints(),
@@ -215,8 +215,8 @@ public class CronDefinitionTest {
                 false,
                 true,
                 false
-            },
-            new Object[] {
+            ),
+            Arguments.of(
                 provideSimpleFieldDefinitions(),
                 provideSimpleFieldDefinitions(),
                 provideCronConstraintSetWithTwoConstraints(),
@@ -226,11 +226,11 @@ public class CronDefinitionTest {
                 false,
                 true,
                 false
-            }
-        };
+            )
+        );
     }
 
-    private List<FieldDefinition> provideFieldDefinitions(CronFieldName cronFieldName, UnaryOperator<FieldConstraintsBuilder> configurator) {
+    private static List<FieldDefinition> provideFieldDefinitions(CronFieldName cronFieldName, UnaryOperator<FieldConstraintsBuilder> configurator) {
         List<FieldDefinition> defs = new ArrayList<>();
         defs.add(new FieldDefinition(cronFieldName, configurator.apply(
                 FieldConstraintsBuilder.instance().forField(cronFieldName)).createConstraintsInstance()));
@@ -238,29 +238,29 @@ public class CronDefinitionTest {
         return defs;
     }
 
-    private List<FieldDefinition> provideSimpleFieldDefinitions() {
+    private static List<FieldDefinition> provideSimpleFieldDefinitions() {
         return provideFieldDefinitions(CronFieldName.SECOND, b -> b);
     }
 
-    private Set<CronNicknames> provideCronNicknameSetWithTwoNicknames() {
+    private static Set<CronNicknames> provideCronNicknameSetWithTwoNicknames() {
         Set<CronNicknames> constraints = provideCronNicknameSetWithOneNickname();
         constraints.add(CronNicknames.DAILY);
         return constraints;
     }
 
-    private Set<CronNicknames> provideCronNicknameSetWithOneNickname() {
+    private static Set<CronNicknames> provideCronNicknameSetWithOneNickname() {
         Set<CronNicknames> constraints = new HashSet<>();
         constraints.add(CronNicknames.ANNUALLY);
         return constraints;
     }
 
-    private Set<CronConstraint> provideCronConstraintSetWithTwoConstraints() {
+    private static Set<CronConstraint> provideCronConstraintSetWithTwoConstraints() {
         Set<CronConstraint> constraints = provideCronConstraintSetWithOneConstraint();
         constraints.add(CronConstraintsFactory.ensureEitherDayOfYearOrMonth());
         return constraints;
     }
 
-    private Set<CronConstraint> provideCronConstraintSetWithOneConstraint() {
+    private static Set<CronConstraint> provideCronConstraintSetWithOneConstraint() {
         Set<CronConstraint> constraints = new HashSet<>();
         constraints.add(CronConstraintsFactory.ensureEitherDayOfWeekOrDayOfMonth());
         return constraints;

--- a/src/test/java/com/cronutils/model/definition/CronDefinitionTest.java
+++ b/src/test/java/com/cronutils/model/definition/CronDefinitionTest.java
@@ -15,7 +15,6 @@ package com.cronutils.model.definition;
 
 import com.cronutils.model.CronType;
 import com.cronutils.model.field.CronFieldName;
-import com.cronutils.model.field.constraint.FieldConstraints;
 import com.cronutils.model.field.constraint.FieldConstraintsBuilder;
 import com.cronutils.model.field.definition.FieldDefinition;
 import junitparams.JUnitParamsRunner;
@@ -30,7 +29,6 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import java.util.function.Consumer;
 import java.util.function.UnaryOperator;
 
 import static org.junit.Assert.*;

--- a/src/test/java/com/cronutils/model/definition/FieldDefinitionTest.java
+++ b/src/test/java/com/cronutils/model/definition/FieldDefinitionTest.java
@@ -16,12 +16,12 @@ package com.cronutils.model.definition;
 import com.cronutils.model.field.CronFieldName;
 import com.cronutils.model.field.constraint.FieldConstraints;
 import com.cronutils.model.field.definition.FieldDefinition;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.mock;
 
 public class FieldDefinitionTest {
@@ -32,21 +32,21 @@ public class FieldDefinitionTest {
 
     private FieldDefinition fieldDefinition;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         MockitoAnnotations.initMocks(this);
         testFieldName = CronFieldName.SECOND;
         fieldDefinition = new FieldDefinition(testFieldName, mockConstraints);
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void testConstructorNullFieldName() {
-        new FieldDefinition(null, mockConstraints);
+        assertThrows(NullPointerException.class, () -> new FieldDefinition(null, mockConstraints));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void testConstructorNullConstraints() {
-        new FieldDefinition(testFieldName, null);
+        assertThrows(NullPointerException.class, () -> new FieldDefinition(testFieldName, null));
     }
 
     @Test

--- a/src/test/java/com/cronutils/model/definition/Issue343Test.java
+++ b/src/test/java/com/cronutils/model/definition/Issue343Test.java
@@ -3,37 +3,23 @@ package com.cronutils.model.definition;
 import com.cronutils.model.Cron;
 import com.cronutils.model.CronType;
 import com.cronutils.parser.CronParser;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
-@RunWith(Parameterized.class)
 public class Issue343Test {
-
-    @Parameterized.Parameters(name = "{0}")
-    public static Object[] expressions() {
-        // List of expressions from https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/scheduling/support/CronSequenceGenerator.html
-        return new Object[]{
-                "0 0 * * * *",
-                "*/10 * * * * *",
-                "0 0 8-10 * * *",
-                "0 0 6,19 * * *",
-                "0 0/30 8-10 * * *",
-                "0 0 9-17 * * MON-FRI",
-                "0 0 0 25 12 ?"
-        };
-    }
-
-    private final String expression;
-
-    public Issue343Test(String expression) {
-        this.expression = expression;
-    }
-
-    @Test
-    public void testSpringCronExpressions() {
+    @ParameterizedTest
+    @ValueSource(strings = {
+        "0 0 * * * *",
+        "*/10 * * * * *",
+        "0 0 8-10 * * *",
+        "0 0 6,19 * * *",
+        "0 0/30 8-10 * * *",
+        "0 0 9-17 * * MON-FRI",
+        "0 0 0 25 12 ?"
+    })
+    public void testSpringCronExpressions(String expression) {
         CronParser parser = new CronParser(CronDefinitionBuilder.instanceDefinitionFor(CronType.SPRING));
 
         try {

--- a/src/test/java/com/cronutils/model/definition/Issue343Test.java
+++ b/src/test/java/com/cronutils/model/definition/Issue343Test.java
@@ -3,10 +3,11 @@ package com.cronutils.model.definition;
 import com.cronutils.model.Cron;
 import com.cronutils.model.CronType;
 import com.cronutils.parser.CronParser;
-import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
+
+import static org.junit.Assert.*;
 
 @RunWith(Parameterized.class)
 public class Issue343Test {
@@ -37,9 +38,9 @@ public class Issue343Test {
 
         try {
             Cron parsed = parser.parse(expression);
-            Assert.assertNotNull(parsed);
+            assertNotNull(parsed);
         } catch (IllegalArgumentException e) {
-            Assert.fail("This expression should pass: " + expression);
+            fail("This expression should pass: " + expression);
         }
     }
 }

--- a/src/test/java/com/cronutils/model/field/CronFieldTest.java
+++ b/src/test/java/com/cronutils/model/field/CronFieldTest.java
@@ -15,14 +15,14 @@ package com.cronutils.model.field;
 
 import com.cronutils.model.field.constraint.FieldConstraintsBuilder;
 import com.cronutils.model.field.expression.FieldExpression;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
 import java.util.Comparator;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -33,7 +33,7 @@ public class CronFieldTest {
     @Mock
     private FieldExpression mockFieldExpression;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         MockitoAnnotations.initMocks(this);
         cronFieldName = CronFieldName.SECOND;

--- a/src/test/java/com/cronutils/model/field/FieldDefinitionBuilderTest.java
+++ b/src/test/java/com/cronutils/model/field/FieldDefinitionBuilderTest.java
@@ -29,7 +29,6 @@ import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 
 import static org.junit.Assert.assertEquals;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
 @Ignore

--- a/src/test/java/com/cronutils/model/field/FieldDefinitionBuilderTest.java
+++ b/src/test/java/com/cronutils/model/field/FieldDefinitionBuilderTest.java
@@ -18,24 +18,21 @@ import com.cronutils.model.field.constraint.FieldConstraints;
 import com.cronutils.model.field.constraint.FieldConstraintsBuilder;
 import com.cronutils.model.field.definition.FieldDefinition;
 import com.cronutils.model.field.definition.FieldDefinitionBuilder;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
-import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
-import org.powermock.api.mockito.PowerMockito;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
 @Ignore
-@RunWith(PowerMockRunner.class)
-@PrepareForTest({ FieldConstraintsBuilder.class, FieldDefinitionBuilder.class })
 public class FieldDefinitionBuilderTest {
     private CronFieldName testFieldName;
     @Mock
@@ -45,16 +42,22 @@ public class FieldDefinitionBuilderTest {
 
     private FieldDefinitionBuilder fieldDefinitionBuilder;
 
+    private MockedStatic<FieldConstraintsBuilder> mockedFieldConstraintsBuilder;
+
     @Before
     public void setUp() {
         MockitoAnnotations.openMocks(this);
         testFieldName = CronFieldName.SECOND;
 
         when(mockConstraintsBuilder.forField(any(CronFieldName.class))).thenReturn(mockConstraintsBuilder);
-        PowerMockito.mockStatic(FieldConstraintsBuilder.class);
-        PowerMockito.when(FieldConstraintsBuilder.instance()).thenReturn(mockConstraintsBuilder);
-
+        mockedFieldConstraintsBuilder = Mockito.mockStatic(FieldConstraintsBuilder.class);
+        mockedFieldConstraintsBuilder.when(FieldConstraintsBuilder::instance).thenReturn(mockConstraintsBuilder);
         fieldDefinitionBuilder = new FieldDefinitionBuilder(mockParserBuilder, testFieldName);
+    }
+
+    @After
+    public void tearDown() {
+        mockedFieldConstraintsBuilder.close();
     }
 
     @Test

--- a/src/test/java/com/cronutils/model/field/FieldDefinitionBuilderTest.java
+++ b/src/test/java/com/cronutils/model/field/FieldDefinitionBuilderTest.java
@@ -18,20 +18,21 @@ import com.cronutils.model.field.constraint.FieldConstraints;
 import com.cronutils.model.field.constraint.FieldConstraintsBuilder;
 import com.cronutils.model.field.definition.FieldDefinition;
 import com.cronutils.model.field.definition.FieldDefinitionBuilder;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.*;
 
-@Ignore
+@Disabled
 public class FieldDefinitionBuilderTest {
     private CronFieldName testFieldName;
     @Mock
@@ -43,7 +44,7 @@ public class FieldDefinitionBuilderTest {
 
     private MockedStatic<FieldConstraintsBuilder> mockedFieldConstraintsBuilder;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         MockitoAnnotations.openMocks(this);
         testFieldName = CronFieldName.SECOND;
@@ -54,7 +55,7 @@ public class FieldDefinitionBuilderTest {
         fieldDefinitionBuilder = new FieldDefinitionBuilder(mockParserBuilder, testFieldName);
     }
 
-    @After
+    @AfterEach
     public void tearDown() {
         mockedFieldConstraintsBuilder.close();
     }
@@ -82,13 +83,13 @@ public class FieldDefinitionBuilderTest {
         verify(mockConstraintsBuilder).createConstraintsInstance();
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void testConstructorNullParserBuilder() {
-        new FieldDefinitionBuilder(null, testFieldName);
+        assertThrows(NullPointerException.class, () -> new FieldDefinitionBuilder(null, testFieldName));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void testConstructorNullTestFieldName() {
-        new FieldDefinitionBuilder(mockParserBuilder, null);
+        assertThrows(NullPointerException.class, () -> new FieldDefinitionBuilder(mockParserBuilder, null));
     }
 }

--- a/src/test/java/com/cronutils/model/field/FieldParserTest.java
+++ b/src/test/java/com/cronutils/model/field/FieldParserTest.java
@@ -16,16 +16,17 @@ import com.cronutils.model.field.expression.*;
 import com.cronutils.model.field.value.IntegerFieldValue;
 import com.cronutils.model.field.value.SpecialChar;
 import com.cronutils.parser.FieldParser;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class FieldParserTest {
     private FieldParser parser;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         parser = new FieldParser(FieldConstraintsBuilder.instance().addHashSupport().createConstraintsInstance());
     }
@@ -59,9 +60,9 @@ public class FieldParserTest {
         assertEquals(SpecialChar.HASH, onExpression.getSpecialChar().getValue());
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testRejectHashIfFieldDoesNotClaimToSupportIt() {
-        new FieldParser(FieldConstraintsBuilder.instance().createConstraintsInstance()).parse("5#3");
+        assertThrows(IllegalArgumentException.class, () -> new FieldParser(FieldConstraintsBuilder.instance().createConstraintsInstance()).parse("5#3"));
     }
 
     @Test
@@ -95,8 +96,8 @@ public class FieldParserTest {
         assertEquals(every, (int) (expression.getPeriod()).getValue());
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void testCostructorNullConstraints() {
-        new FieldParser(null);
+        assertThrows(NullPointerException.class, () -> new FieldParser(null));
     }
 }

--- a/src/test/java/com/cronutils/model/field/constraints/FieldConstraintsTest.java
+++ b/src/test/java/com/cronutils/model/field/constraints/FieldConstraintsTest.java
@@ -15,12 +15,14 @@ package com.cronutils.model.field.constraints;
 
 import com.cronutils.model.field.constraint.FieldConstraints;
 import com.cronutils.model.field.value.SpecialChar;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class FieldConstraintsTest {
 
@@ -31,7 +33,7 @@ public class FieldConstraintsTest {
     private int endRange;
     private boolean strictRange;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         intMapping = Collections.emptyMap();
         stringMapping = Collections.emptyMap();
@@ -41,18 +43,18 @@ public class FieldConstraintsTest {
         strictRange = true;
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void testConstructorStringMappingNull() {
-        new FieldConstraints(null, intMapping, specialCharSet, startRange, endRange, strictRange);
+        assertThrows(NullPointerException.class, () -> new FieldConstraints(null, intMapping, specialCharSet, startRange, endRange, strictRange));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void testConstructorIntMappingNull() {
-        new FieldConstraints(stringMapping, null, specialCharSet, startRange, endRange, strictRange);
+        assertThrows(NullPointerException.class, () -> new FieldConstraints(stringMapping, null, specialCharSet, startRange, endRange, strictRange));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void testSpecialCharsSetNull() {
-        new FieldConstraints(stringMapping, intMapping, null, startRange, endRange, strictRange);
+        assertThrows(NullPointerException.class, () -> new FieldConstraints(stringMapping, intMapping, null, startRange, endRange, strictRange));
     }
 }

--- a/src/test/java/com/cronutils/model/field/expression/AlwaysTest.java
+++ b/src/test/java/com/cronutils/model/field/expression/AlwaysTest.java
@@ -13,9 +13,9 @@
 
 package com.cronutils.model.field.expression;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class AlwaysTest {
 

--- a/src/test/java/com/cronutils/model/field/expression/AndTest.java
+++ b/src/test/java/com/cronutils/model/field/expression/AndTest.java
@@ -13,10 +13,11 @@
 
 package com.cronutils.model.field.expression;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -26,7 +27,7 @@ public class AndTest {
     private FieldExpression expression1;
     private FieldExpression expression2;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         and = new And();
         expression1 = mock(FieldExpression.class);
@@ -41,9 +42,9 @@ public class AndTest {
         assertEquals(expression2, and.getExpressions().get(1));
     }
 
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void testGetExpressionsImmutable() {
-        and.and(expression1).getExpressions().add(expression2);
+        assertThrows(UnsupportedOperationException.class, () -> and.and(expression1).getExpressions().add(expression2));
     }
 
     @Test

--- a/src/test/java/com/cronutils/model/field/expression/BetweenTest.java
+++ b/src/test/java/com/cronutils/model/field/expression/BetweenTest.java
@@ -16,16 +16,16 @@ package com.cronutils.model.field.expression;
 import com.cronutils.model.field.value.IntegerFieldValue;
 import com.cronutils.model.field.value.SpecialChar;
 import com.cronutils.model.field.value.SpecialCharFieldValue;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class BetweenTest {
     private int from;
     private int to;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         from = 1;
         to = 5;

--- a/src/test/java/com/cronutils/model/field/expression/EveryTest.java
+++ b/src/test/java/com/cronutils/model/field/expression/EveryTest.java
@@ -14,9 +14,9 @@
 package com.cronutils.model.field.expression;
 
 import com.cronutils.model.field.value.IntegerFieldValue;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class EveryTest {
     @Test

--- a/src/test/java/com/cronutils/model/field/expression/FieldExpressionTest.java
+++ b/src/test/java/com/cronutils/model/field/expression/FieldExpressionTest.java
@@ -15,16 +15,16 @@ package com.cronutils.model.field.expression;
 
 import com.cronutils.model.field.expression.visitor.*;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 
 public class FieldExpressionTest {
     private TestFieldExpression testCronFieldExpression;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         testCronFieldExpression = new TestFieldExpression();
     }

--- a/src/test/java/com/cronutils/model/field/expression/OnTest.java
+++ b/src/test/java/com/cronutils/model/field/expression/OnTest.java
@@ -16,16 +16,17 @@ package com.cronutils.model.field.expression;
 import com.cronutils.model.field.value.IntegerFieldValue;
 import com.cronutils.model.field.value.SpecialChar;
 import com.cronutils.model.field.value.SpecialCharFieldValue;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class OnTest {
     private int time;
     private int nth;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         time = 5;
         nth = 3;
@@ -42,9 +43,9 @@ public class OnTest {
                 (int) new On(new IntegerFieldValue(time), new SpecialCharFieldValue(SpecialChar.HASH), new IntegerFieldValue(nth)).getNth().getValue());
     }
 
-    @Test(expected = RuntimeException.class)
+    @Test
     public void testOnlyNthFails() {
-        new On(null, new SpecialCharFieldValue(SpecialChar.HASH), new IntegerFieldValue(nth));
+        assertThrows(RuntimeException.class, () -> new On(null, new SpecialCharFieldValue(SpecialChar.HASH), new IntegerFieldValue(nth)));
     }
 
     @Test

--- a/src/test/java/com/cronutils/model/field/expression/visitor/ValidationFieldExpressionVisitorTest.java
+++ b/src/test/java/com/cronutils/model/field/expression/visitor/ValidationFieldExpressionVisitorTest.java
@@ -16,7 +16,6 @@ import org.mockito.MockitoAnnotations;
 import java.util.Collections;
 
 import static org.junit.Assert.*;
-import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.*;
 
 public class ValidationFieldExpressionVisitorTest {

--- a/src/test/java/com/cronutils/model/field/expression/visitor/ValidationFieldExpressionVisitorTest.java
+++ b/src/test/java/com/cronutils/model/field/expression/visitor/ValidationFieldExpressionVisitorTest.java
@@ -7,15 +7,15 @@ import com.cronutils.model.field.value.IntegerFieldValue;
 import com.cronutils.model.field.value.SpecialChar;
 import com.cronutils.model.field.value.SpecialCharFieldValue;
 import com.cronutils.utils.StringUtils;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 
 import java.util.Collections;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
 public class ValidationFieldExpressionVisitorTest {
@@ -40,7 +40,7 @@ public class ValidationFieldExpressionVisitorTest {
     private ValidationFieldExpressionVisitor strictVisitor;
     private ValidationFieldExpressionVisitor visitor;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         MockitoAnnotations.initMocks(this);
         final int startRange = 0;
@@ -54,11 +54,11 @@ public class ValidationFieldExpressionVisitorTest {
         visitor = new ValidationFieldExpressionVisitor(fieldConstraints, stringValidations);
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testVisitWithInvalidChars() {
         final ValidationFieldExpressionVisitor tempVisitor = new ValidationFieldExpressionVisitor(fieldConstraints, invalidStringValidations);
         final FieldExpression exp = FieldExpression.always();
-        exp.accept(tempVisitor);
+        assertThrows(IllegalArgumentException.class, () -> exp.accept(tempVisitor));
     }
 
     @Test
@@ -132,16 +132,16 @@ public class ValidationFieldExpressionVisitorTest {
         qm.accept(verify(strictSpy, times(1)));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testStrictVisitBadExp() {
         final FieldExpression exp = new Between(new IntegerFieldValue(HIGH), new IntegerFieldValue(LOW));
-        exp.accept(strictVisitor);
+        assertThrows(IllegalArgumentException.class, () -> exp.accept(strictVisitor));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testVisitBadExp() {
         final FieldExpression exp = new Between(new IntegerFieldValue(LOWOOR), new IntegerFieldValue(HIGH));
-        exp.accept(visitor);
+        assertThrows(IllegalArgumentException.class, () -> exp.accept(visitor));
     }
 
     @Test
@@ -173,54 +173,54 @@ public class ValidationFieldExpressionVisitorTest {
         assertEquals(between, between.accept(visitor));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testStrictVisitBetweenWrongSpecialChars() {
-        new Between(new IntegerFieldValue(LOW), new SpecialCharFieldValue(SpecialChar.LW)).accept(strictVisitor);
+        assertThrows(IllegalArgumentException.class, () -> new Between(new IntegerFieldValue(LOW), new SpecialCharFieldValue(SpecialChar.LW)).accept(strictVisitor));
 
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testStrictVisitBetweenOORangeBottom() {
-        new Between(new IntegerFieldValue(LOWOOR), new IntegerFieldValue(HIGH)).accept(strictVisitor);
+        assertThrows(IllegalArgumentException.class, () -> new Between(new IntegerFieldValue(LOWOOR), new IntegerFieldValue(HIGH)).accept(strictVisitor));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testStrictVisitBetweenOORangeTop() {
-        new Between(new IntegerFieldValue(LOW), new IntegerFieldValue(HIGHOOR)).accept(strictVisitor);
+        assertThrows(IllegalArgumentException.class, () -> new Between(new IntegerFieldValue(LOW), new IntegerFieldValue(HIGHOOR)).accept(strictVisitor));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testStrictVisitBetweenOORange() {
-        new Between(new IntegerFieldValue(LOWOOR), new IntegerFieldValue(HIGHOOR)).accept(strictVisitor);
+        assertThrows(IllegalArgumentException.class, () -> new Between(new IntegerFieldValue(LOWOOR), new IntegerFieldValue(HIGHOOR)).accept(strictVisitor));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testStrictVisitBetweenOOOrder() {
-        new Between(new IntegerFieldValue(HIGH), new IntegerFieldValue(LOW)).accept(strictVisitor);
+        assertThrows(IllegalArgumentException.class, () -> new Between(new IntegerFieldValue(HIGH), new IntegerFieldValue(LOW)).accept(strictVisitor));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testVisitBetweenWrongSpecialChars() {
-        new Between(new IntegerFieldValue(LOW), new SpecialCharFieldValue(SpecialChar.LW)).accept(visitor);
+        assertThrows(IllegalArgumentException.class, () -> new Between(new IntegerFieldValue(LOW), new SpecialCharFieldValue(SpecialChar.LW)).accept(visitor));
 
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testVisitBetweenOORangeBottom() {
-        new Between(new IntegerFieldValue(LOWOOR), new IntegerFieldValue(HIGH)).accept(visitor);
+        assertThrows(IllegalArgumentException.class, () -> new Between(new IntegerFieldValue(LOWOOR), new IntegerFieldValue(HIGH)).accept(visitor));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testVisitBetweenOORangeTop() {
-        new Between(new IntegerFieldValue(LOW), new IntegerFieldValue(HIGHOOR)).accept(visitor);
+        assertThrows(IllegalArgumentException.class, () -> new Between(new IntegerFieldValue(LOW), new IntegerFieldValue(HIGHOOR)).accept(visitor));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testVisitBetweenOORange() {
-        new Between(new IntegerFieldValue(LOWOOR), new IntegerFieldValue(HIGHOOR)).accept(visitor);
+        assertThrows(IllegalArgumentException.class, () -> new Between(new IntegerFieldValue(LOWOOR), new IntegerFieldValue(HIGHOOR)).accept(visitor));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testVisitBetweenOOOrderStrict() {
         final int startRange = 0;
         final int endRange = 59;
@@ -228,7 +228,7 @@ public class ValidationFieldExpressionVisitorTest {
         visitor = new ValidationFieldExpressionVisitor(fieldConstraints, stringValidations);
 
         final Between between = new Between(new IntegerFieldValue(HIGH), new IntegerFieldValue(LOW));
-        assertEquals(between, between.accept(visitor));
+        assertThrows(IllegalArgumentException.class, () -> assertEquals(between, between.accept(visitor)));
     }
 
     @Test
@@ -269,58 +269,62 @@ public class ValidationFieldExpressionVisitorTest {
         on.accept(verify(strictSpy, times(1)));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testStrictVisitEveryOORange() {
-        new Every(new IntegerFieldValue(HIGHOOR)).accept(strictVisitor);
+        assertThrows(IllegalArgumentException.class, () -> new Every(new IntegerFieldValue(HIGHOOR)).accept(strictVisitor));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testStrictVisitEveryOORangeBetween() {
-        new Every(new Between(new IntegerFieldValue(LOW), new IntegerFieldValue(MIDDLE)),
-                new IntegerFieldValue(HIGHOOR)).accept(strictVisitor);
+        assertThrows(IllegalArgumentException.class,
+                () -> new Every(new Between(new IntegerFieldValue(LOW), new IntegerFieldValue(MIDDLE)),
+                        new IntegerFieldValue(HIGHOOR)).accept(strictVisitor));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testStrictVisitEveryOORangeOn() {
-        new Every(new On(new IntegerFieldValue(LOW)), new IntegerFieldValue(HIGHOOR)).accept(strictVisitor);
+        assertThrows(IllegalArgumentException.class, () -> new Every(new On(new IntegerFieldValue(LOW)), new IntegerFieldValue(HIGHOOR)).accept(strictVisitor));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testStrictVisitEveryOORangeBadBetween() {
-        new Every(new Between(new IntegerFieldValue(LOWOOR), new IntegerFieldValue(MIDDLE)),
-                new IntegerFieldValue(HIGH)).accept(strictVisitor);
+        assertThrows(IllegalArgumentException.class,
+                () -> new Every(new Between(new IntegerFieldValue(LOWOOR), new IntegerFieldValue(MIDDLE)),
+                        new IntegerFieldValue(HIGH)).accept(strictVisitor));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testStrictVisitEveryOORangeBadOn() {
-        new Every(new On(new IntegerFieldValue(HIGHOOR)), new IntegerFieldValue(HIGH)).accept(strictVisitor);
+        assertThrows(IllegalArgumentException.class, () -> new Every(new On(new IntegerFieldValue(HIGHOOR)), new IntegerFieldValue(HIGH)).accept(strictVisitor));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testVisitEveryOORange() {
-        new Every(new IntegerFieldValue(HIGHOOR)).accept(visitor);
+        assertThrows(IllegalArgumentException.class, () -> new Every(new IntegerFieldValue(HIGHOOR)).accept(visitor));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testVisitEveryOORangeBetween() {
-        new Every(new Between(new IntegerFieldValue(LOW), new IntegerFieldValue(MIDDLE)),
-                new IntegerFieldValue(HIGHOOR)).accept(visitor);
+        assertThrows(IllegalArgumentException.class,
+                () -> new Every(new Between(new IntegerFieldValue(LOW), new IntegerFieldValue(MIDDLE)),
+                        new IntegerFieldValue(HIGHOOR)).accept(visitor));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testVisitEveryOORangeOn() {
-        new Every(new On(new IntegerFieldValue(LOW)), new IntegerFieldValue(HIGHOOR)).accept(visitor);
+        assertThrows(IllegalArgumentException.class, () -> new Every(new On(new IntegerFieldValue(LOW)), new IntegerFieldValue(HIGHOOR)).accept(visitor));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testVisitEveryOORangeBadBetween() {
-        new Every(new Between(new IntegerFieldValue(LOWOOR), new IntegerFieldValue(MIDDLE)),
-                new IntegerFieldValue(HIGH)).accept(strictVisitor);
+        assertThrows(IllegalArgumentException.class,
+                () -> new Every(new Between(new IntegerFieldValue(LOWOOR), new IntegerFieldValue(MIDDLE)),
+                        new IntegerFieldValue(HIGH)).accept(strictVisitor));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testVisitEveryOORangeBadOn() {
-        new Every(new On(new IntegerFieldValue(HIGHOOR)), new IntegerFieldValue(HIGH)).accept(strictVisitor);
+        assertThrows(IllegalArgumentException.class, () -> new Every(new On(new IntegerFieldValue(HIGHOOR)), new IntegerFieldValue(HIGH)).accept(strictVisitor));
     }
 
     @Test
@@ -347,26 +351,28 @@ public class ValidationFieldExpressionVisitorTest {
         assertEquals(on, on.accept(visitor));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testStrictVisitOnBadTime() {
-        new On(new IntegerFieldValue(LOWOOR)).accept(strictVisitor);
+        assertThrows(IllegalArgumentException.class, () -> new On(new IntegerFieldValue(LOWOOR)).accept(strictVisitor));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testStrictVisitOnBadNth() {
-        new On(new IntegerFieldValue(LOW), new SpecialCharFieldValue(SpecialChar.LW),
-                new IntegerFieldValue(HIGHOOR)).accept(strictVisitor);
+        assertThrows(IllegalArgumentException.class,
+                () -> new On(new IntegerFieldValue(LOW), new SpecialCharFieldValue(SpecialChar.LW),
+                        new IntegerFieldValue(HIGHOOR)).accept(strictVisitor));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testVisitOnBadTime() {
-        new On(new IntegerFieldValue(LOWOOR)).accept(visitor);
+        assertThrows(IllegalArgumentException.class, () -> new On(new IntegerFieldValue(LOWOOR)).accept(visitor));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testVisitOnBadNth() {
-        new On(new IntegerFieldValue(LOW), new SpecialCharFieldValue(SpecialChar.LW),
-                new IntegerFieldValue(HIGHOOR)).accept(visitor);
+        assertThrows(IllegalArgumentException.class,
+                () -> new On(new IntegerFieldValue(LOW), new SpecialCharFieldValue(SpecialChar.LW),
+                        new IntegerFieldValue(HIGHOOR)).accept(visitor));
     }
 
     @Test
@@ -396,24 +402,24 @@ public class ValidationFieldExpressionVisitorTest {
         assertEquals(and, and.accept(strictVisitor));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testStrictVisitAndBadExpression() {
         final And and = new And();
         final Between b1 = new Between(new IntegerFieldValue(LOW), new IntegerFieldValue(MIDDLE));
         final Between b2 = new Between(new IntegerFieldValue(MIDDLE), new IntegerFieldValue(HIGHOOR));
         final On on = new On(new IntegerFieldValue(LOW));
         and.and(b1).and(b2).and(b2).and(on);
-        and.accept(strictVisitor);
+        assertThrows(IllegalArgumentException.class, () -> and.accept(strictVisitor));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testVisitAndBadExpression() {
         final And and = new And();
         final Between b1 = new Between(new IntegerFieldValue(LOW), new IntegerFieldValue(MIDDLE));
         final Between b2 = new Between(new IntegerFieldValue(MIDDLE), new IntegerFieldValue(HIGHOOR));
         final On on = new On(new IntegerFieldValue(LOW));
         and.and(b1).and(b2).and(b2).and(on);
-        and.accept(visitor);
+        assertThrows(IllegalArgumentException.class, () -> and.accept(visitor));
     }
 
     @Test
@@ -470,10 +476,10 @@ public class ValidationFieldExpressionVisitorTest {
         visitor.isInRange(integerValue);
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testIsInRangeOORangeStrict() {
         final IntegerFieldValue integerValue = new IntegerFieldValue(HIGHOOR);
-        strictVisitor.isInRange(integerValue);
+        assertThrows(IllegalArgumentException.class, () -> strictVisitor.isInRange(integerValue));
     }
 
 }

--- a/src/test/java/com/cronutils/model/field/expression/visitor/ValueMappingFieldExpressionVisitorTest.java
+++ b/src/test/java/com/cronutils/model/field/expression/visitor/ValueMappingFieldExpressionVisitorTest.java
@@ -17,15 +17,15 @@ import com.cronutils.Function;
 import com.cronutils.model.field.expression.FieldExpression;
 import com.cronutils.model.field.expression.QuestionMark;
 import com.cronutils.model.field.value.FieldValue;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class ValueMappingFieldExpressionVisitorTest {
     private ValueMappingFieldExpressionVisitor valueMappingFieldExpressionVisitor;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         final Function<FieldValue<?>, FieldValue<?>> transform = input -> input;
         valueMappingFieldExpressionVisitor = new ValueMappingFieldExpressionVisitor(transform);

--- a/src/test/java/com/cronutils/model/time/ExecutionTimeCron4jIntegrationTest.java
+++ b/src/test/java/com/cronutils/model/time/ExecutionTimeCron4jIntegrationTest.java
@@ -10,8 +10,8 @@ package com.cronutils.model.time;
 import com.cronutils.model.CronType;
 import com.cronutils.model.definition.CronDefinitionBuilder;
 import com.cronutils.parser.CronParser;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -22,7 +22,7 @@ import java.time.ZonedDateTime;
 import java.util.Optional;
 import java.util.Random;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class ExecutionTimeCron4jIntegrationTest {
     private CronParser cron4jCronParser;
@@ -35,7 +35,7 @@ public class ExecutionTimeCron4jIntegrationTest {
     private static final String LOG_LAST_RUN = "LastRun = [{}]";
     private static final String LOG_NEXT_RUN = "NextRun = [{}]";
 
-    @Before
+    @BeforeEach
     public void setUp() {
         cron4jCronParser = new CronParser(CronDefinitionBuilder.instanceDefinitionFor(CronType.CRON4J));
     }
@@ -91,8 +91,8 @@ public class ExecutionTimeCron4jIntegrationTest {
                 log.info(LOG_LAST_RUN, lastRun);
                 log.info(LOG_NEXT_RUN, nextRun);
 
-                assertTrue(String.format("Hour is %s", nextRun.getHour()), nextRun.getHour() % 2 == 0);
-                assertTrue(String.format("Last run is before next one: %s", lastRun.isBefore(nextRun)), lastRun.isBefore(nextRun));
+                assertTrue(nextRun.getHour() % 2 == 0, String.format("Hour is %s", nextRun.getHour()));
+                assertTrue(lastRun.isBefore(nextRun), String.format("Last run is before next one: %s", lastRun.isBefore(nextRun)));
                 lastRun = lastRun.plusHours(1);
             } else {
                 fail(NEXT_EXECUTION_NOT_PRESENT_ERROR);
@@ -115,8 +115,8 @@ public class ExecutionTimeCron4jIntegrationTest {
                 log.info(LOG_LAST_RUN, lastRun);
                 log.info(LOG_NEXT_RUN, nextRun);
 
-                assertTrue(String.format("Hour is %s", nextRun.getHour()), nextRun.getHour() % 2 == 0);
-                assertTrue(String.format("Last run is before next one: %s", lastRun.isBefore(nextRun)), lastRun.isBefore(nextRun));
+                assertTrue(nextRun.getHour() % 2 == 0, String.format("Hour is %s", nextRun.getHour()));
+                assertTrue(lastRun.isBefore(nextRun), String.format("Last run is before next one: %s", lastRun.isBefore(nextRun)));
                 lastRun = lastRun.plusHours(1);
             } else {
                 fail(NEXT_EXECUTION_NOT_PRESENT_ERROR);
@@ -220,11 +220,11 @@ public class ExecutionTimeCron4jIntegrationTest {
             next = nextExecution.get();
             final ZonedDateTime expectedDate = ZonedDateTime.of(expectedYear, 1, 1, 9, 0, 0, 0, ZoneId.systemDefault());
             final String expectedMessage = String.format("Expected next execution time: %s, Actual next execution time: %s", expectedDate, next);
-            assertEquals(expectedMessage, DayOfWeek.TUESDAY, next.getDayOfWeek());
-            assertEquals(expectedMessage, 1, next.getDayOfMonth());
-            assertEquals(expectedMessage, expectedYear, next.getYear());
-            assertEquals(expectedMessage, 9, next.getHour());
-            assertEquals(expectedMessage, expectedDate, next);
+            assertEquals(DayOfWeek.TUESDAY, next.getDayOfWeek(), expectedMessage);
+            assertEquals(1, next.getDayOfMonth(), expectedMessage);
+            assertEquals(expectedYear, next.getYear(), expectedMessage);
+            assertEquals(9, next.getHour(), expectedMessage);
+            assertEquals(expectedDate, next, expectedMessage);
         }
     }
 
@@ -254,9 +254,9 @@ public class ExecutionTimeCron4jIntegrationTest {
             assert (nextExecution.isPresent());
             next = nextExecution.get();
             log.debug("Execution #{} date: {}", i, next);
-            assertEquals("Incorrect day of the week", dayOfWeek, next.getDayOfWeek());
-            assertEquals("Incorrect day of the month", dayOfMonth, next.getDayOfMonth());
-            assertEquals("Incorrect month", month, next.getMonthValue());
+            assertEquals(dayOfWeek, next.getDayOfWeek(), "Incorrect day of the week");
+            assertEquals(dayOfMonth, next.getDayOfMonth(), "Incorrect day of the month");
+            assertEquals(month, next.getMonthValue(), "Incorrect month");
         }
     }
 

--- a/src/test/java/com/cronutils/model/time/ExecutionTimeCustomDefinitionIntegrationTest.java
+++ b/src/test/java/com/cronutils/model/time/ExecutionTimeCustomDefinitionIntegrationTest.java
@@ -11,14 +11,14 @@ import com.cronutils.model.Cron;
 import com.cronutils.model.definition.CronDefinition;
 import com.cronutils.model.definition.CronDefinitionBuilder;
 import com.cronutils.parser.CronParser;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.util.Optional;
 
 import static java.time.ZoneOffset.UTC;
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class ExecutionTimeCustomDefinitionIntegrationTest {
 

--- a/src/test/java/com/cronutils/model/time/ExecutionTimeQuartzIntegrationTest.java
+++ b/src/test/java/com/cronutils/model/time/ExecutionTimeQuartzIntegrationTest.java
@@ -17,7 +17,6 @@ import com.cronutils.descriptor.CronDescriptor;
 import com.cronutils.model.Cron;
 import com.cronutils.model.definition.CronDefinitionBuilder;
 import com.cronutils.parser.CronParser;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
@@ -902,13 +901,13 @@ public class ExecutionTimeQuartzIntegrationTest {
         ZonedDateTime dateTimeBefore1970 = ZonedDateTime.of(1900, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC);
         Optional<ZonedDateTime> next = execution.nextExecution(dateTimeBefore1970);
         assertTrue(next.isPresent());
-        Assert.assertEquals(ZonedDateTime.of(1970, 1, 1, 12, 0, 0, 0, ZoneOffset.UTC), next.get());
+        assertEquals(ZonedDateTime.of(1970, 1, 1, 12, 0, 0, 0, ZoneOffset.UTC), next.get());
 
         // After 2099
         ZonedDateTime dateTimeAfter2099 = ZonedDateTime.of(2150, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC);
         Optional<ZonedDateTime> last = execution.lastExecution(dateTimeAfter2099);
         assertTrue(last.isPresent());
-        Assert.assertEquals(ZonedDateTime.of(2099, 12, 31, 12, 0, 0, 0, ZoneOffset.UTC), last.get());
+        assertEquals(ZonedDateTime.of(2099, 12, 31, 12, 0, 0, 0, ZoneOffset.UTC), last.get());
     }
 
     private Duration getMinimumInterval(final String quartzPattern) {

--- a/src/test/java/com/cronutils/model/time/ExecutionTimeQuartzWithDayOfYearExtensionIntegrationTest.java
+++ b/src/test/java/com/cronutils/model/time/ExecutionTimeQuartzWithDayOfYearExtensionIntegrationTest.java
@@ -15,16 +15,16 @@ import com.cronutils.model.CronType;
 import com.cronutils.model.definition.CronDefinitionBuilder;
 import com.cronutils.model.definition.TestCronDefinitionsFactory;
 import com.cronutils.parser.CronParser;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.util.Optional;
 
 import static java.time.ZoneOffset.UTC;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class ExecutionTimeQuartzWithDayOfYearExtensionIntegrationTest {
     private static final String BI_WEEKLY_STARTING_WITH_FIRST_DAY_OF_YEAR = "0 0 0 ? * ? * 1/14";
@@ -39,7 +39,7 @@ public class ExecutionTimeQuartzWithDayOfYearExtensionIntegrationTest {
     private CronParser parser;
     private CronParser quartzParser;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         parser = new CronParser(TestCronDefinitionsFactory.withDayOfYearDefinitionWhereYearAndDoYOptionals());
         quartzParser = new CronParser(CronDefinitionBuilder.instanceDefinitionFor(CronType.QUARTZ));
@@ -63,7 +63,7 @@ public class ExecutionTimeQuartzWithDayOfYearExtensionIntegrationTest {
             final ZonedDateTime expected = now.plusDays(14L - dayOfMostRecentPeriod);
             final Optional<ZonedDateTime> nextExecution = executionTime.nextExecution(now);
             if (nextExecution.isPresent()) {
-                assertEquals("Wrong next time from " + now, expected, nextExecution.get());
+                assertEquals(expected, nextExecution.get(), "Wrong next time from " + now);
             } else {
                 fail(NEXT_EXECUTION_NOT_PRESENT_ERROR);
             }
@@ -80,7 +80,7 @@ public class ExecutionTimeQuartzWithDayOfYearExtensionIntegrationTest {
             final ZonedDateTime expected = now.minusDays(dayOfMostRecentPeriod == 0 ? 14 : dayOfMostRecentPeriod);
             final Optional<ZonedDateTime> lastExecution = executionTime.lastExecution(now);
             if (lastExecution.isPresent()) {
-                assertEquals("Wrong next time from " + now, expected, lastExecution.get());
+                assertEquals(expected, lastExecution.get(), "Wrong next time from " + now);
             } else {
                 fail(LAST_EXECUTION_NOT_PRESENT_ERROR);
             }

--- a/src/test/java/com/cronutils/model/time/NearestValueTest.java
+++ b/src/test/java/com/cronutils/model/time/NearestValueTest.java
@@ -13,10 +13,10 @@
 
 package com.cronutils.model.time;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class NearestValueTest {
     private int value;
@@ -24,7 +24,7 @@ public class NearestValueTest {
 
     private NearestValue nearestValue;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         value = 1;
         shifts = 1;

--- a/src/test/java/com/cronutils/model/time/TimeNodeTest.java
+++ b/src/test/java/com/cronutils/model/time/TimeNodeTest.java
@@ -13,15 +13,16 @@
 
 package com.cronutils.model.time;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class TimeNodeTest {
     private static final int LIST_START_VALUE = 2;
@@ -32,7 +33,7 @@ public class TimeNodeTest {
     private List<Integer> values;
     private TimeNode timeNode;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         values = new ArrayList<>();
         values.add(LIST_START_VALUE);
@@ -82,7 +83,7 @@ public class TimeNodeTest {
         final AtomicInteger shift = new AtomicInteger(0);
         final List<Integer> list = Arrays.asList(1, 2, 3, 4);
         final int value = timeNode.getValueFromList(list, index, shift);
-        assertEquals(String.format("Shift was: %s; expected: %s", shift.get(), expectedShifts), expectedShifts, shift.get());
+        assertEquals(expectedShifts, shift.get(), String.format("Shift was: %s; expected: %s", shift.get(), expectedShifts));
         assertEquals((int) list.get(list.size() + index), value);
     }
 
@@ -93,17 +94,17 @@ public class TimeNodeTest {
         final AtomicInteger shift = new AtomicInteger(0);
         final List<Integer> list = Arrays.asList(1, 2, 3, 4);
         final int value = timeNode.getValueFromList(list, index, shift);
-        assertEquals(String.format("Shift was: %s; expected: %s", shift.get(), expectedShifts), expectedShifts, shift.get());
+        assertEquals(expectedShifts, shift.get(), String.format("Shift was: %s; expected: %s", shift.get(), expectedShifts));
         assertEquals((int) list.get(index), value);
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testGetValueFromListWithEmptyList() {
-        timeNode.getValueFromList(new ArrayList<>(), 0, new AtomicInteger(0));
+        assertThrows(IllegalArgumentException.class, () -> timeNode.getValueFromList(new ArrayList<>(), 0, new AtomicInteger(0)));
     }
 
     private void assertResult(final int value, final int shift, final NearestValue nearestValue) {
-        assertEquals(String.format("Values do not match! Expected: %s Found: %s", value, nearestValue.getValue()), value, nearestValue.getValue());
-        assertEquals(String.format("Shifts do not match! Expected: %s Found: %s", shift, nearestValue.getShifts()), shift, nearestValue.getShifts());
+        assertEquals(value, nearestValue.getValue(), String.format("Values do not match! Expected: %s Found: %s", value, nearestValue.getValue()));
+        assertEquals(shift, nearestValue.getShifts(), String.format("Shifts do not match! Expected: %s Found: %s", shift, nearestValue.getShifts()));
     }
 }

--- a/src/test/java/com/cronutils/model/time/generator/AlwaysFieldValueGeneratorTest.java
+++ b/src/test/java/com/cronutils/model/time/generator/AlwaysFieldValueGeneratorTest.java
@@ -18,19 +18,19 @@ import com.cronutils.model.field.CronFieldName;
 import com.cronutils.model.field.constraint.FieldConstraintsBuilder;
 import com.cronutils.model.field.expression.Always;
 import com.cronutils.model.field.expression.FieldExpression;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 import java.util.Random;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.mock;
 
 public class AlwaysFieldValueGeneratorTest {
     private AlwaysFieldValueGenerator fieldValueGenerator;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         fieldValueGenerator = new AlwaysFieldValueGenerator(
                 new CronField(CronFieldName.HOUR, FieldExpression.always(), FieldConstraintsBuilder.instance().createConstraintsInstance()));
@@ -71,9 +71,10 @@ public class AlwaysFieldValueGeneratorTest {
         assertFalse(fieldValueGenerator.matchesFieldExpressionClass(mock(FieldExpression.class)));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testConstructorNotMatchesAlways() {
-        new AlwaysFieldValueGenerator(
-                new CronField(CronFieldName.HOUR, mock(FieldExpression.class), FieldConstraintsBuilder.instance().createConstraintsInstance()));
+        assertThrows(IllegalArgumentException.class,
+                () -> new AlwaysFieldValueGenerator(
+                        new CronField(CronFieldName.HOUR, mock(FieldExpression.class), FieldConstraintsBuilder.instance().createConstraintsInstance())));
     }
 }

--- a/src/test/java/com/cronutils/model/time/generator/AndFieldValueGeneratorTest.java
+++ b/src/test/java/com/cronutils/model/time/generator/AndFieldValueGeneratorTest.java
@@ -21,12 +21,12 @@ import com.cronutils.model.field.expression.And;
 import com.cronutils.model.field.expression.FieldExpression;
 import com.cronutils.model.field.expression.On;
 import com.cronutils.model.field.value.IntegerFieldValue;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.mock;
 
 public class AndFieldValueGeneratorTest {
@@ -39,7 +39,7 @@ public class AndFieldValueGeneratorTest {
 
     private static final int NOT_CONSIDERED_VALUE = 7;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         constraints = FieldConstraintsBuilder.instance().createConstraintsInstance();
         fieldValueGenerator =
@@ -54,20 +54,20 @@ public class AndFieldValueGeneratorTest {
                 );
     }
 
-    @Test(expected = NoSuchValueException.class)
+    @Test
     public void testGenerateNextValue() throws NoSuchValueException {
         assertEquals(VALUE0, fieldValueGenerator.generateNextValue(VALUE0 - 1));
         assertEquals(VALUE1, fieldValueGenerator.generateNextValue(VALUE1 - 1));
         assertEquals(VALUE2, fieldValueGenerator.generateNextValue(VALUE2 - 1));
-        fieldValueGenerator.generateNextValue(VALUE2);
+        assertThrows(NoSuchValueException.class, () -> fieldValueGenerator.generateNextValue(VALUE2));
     }
 
-    @Test(expected = NoSuchValueException.class)
+    @Test
     public void testGeneratePreviousValue() throws NoSuchValueException {
         assertEquals(VALUE2, fieldValueGenerator.generatePreviousValue(VALUE2 + 1));
         assertEquals(VALUE1, fieldValueGenerator.generatePreviousValue(VALUE1 + 1));
         assertEquals(VALUE0, fieldValueGenerator.generatePreviousValue(VALUE0 + 1));
-        fieldValueGenerator.generatePreviousValue(VALUE0);
+        assertThrows(NoSuchValueException.class, () -> fieldValueGenerator.generatePreviousValue(VALUE0));
     }
 
     @Test
@@ -91,8 +91,8 @@ public class AndFieldValueGeneratorTest {
         assertFalse(fieldValueGenerator.matchesFieldExpressionClass(mock(FieldExpression.class)));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testConstructorNotMatchesAnd() {
-        new AndFieldValueGenerator(new CronField(CronFieldName.HOUR, mock(FieldExpression.class), constraints));
+        assertThrows(IllegalArgumentException.class, () -> new AndFieldValueGenerator(new CronField(CronFieldName.HOUR, mock(FieldExpression.class), constraints)));
     }
 }

--- a/src/test/java/com/cronutils/model/time/generator/BetweenDayOfWeekValueGeneratorTest.java
+++ b/src/test/java/com/cronutils/model/time/generator/BetweenDayOfWeekValueGeneratorTest.java
@@ -19,11 +19,11 @@ import com.cronutils.model.field.CronFieldName;
 import com.cronutils.model.field.constraint.FieldConstraintsBuilder;
 import com.cronutils.model.field.expression.Between;
 import com.cronutils.model.field.value.IntegerFieldValue;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class BetweenDayOfWeekValueGeneratorTest {
 
@@ -44,7 +44,7 @@ public class BetweenDayOfWeekValueGeneratorTest {
 
     private void validateInterval(final int start, final int end, final List<Integer> values) {
         for (int j = start; j < end + 1; j++) {
-            assertTrue(String.format("%s not contained in values", j), values.contains(j));
+            assertTrue(values.contains(j), String.format("%s not contained in values", j));
         }
     }
 }

--- a/src/test/java/com/cronutils/model/time/generator/BetweenFieldValueGeneratorTest.java
+++ b/src/test/java/com/cronutils/model/time/generator/BetweenFieldValueGeneratorTest.java
@@ -20,12 +20,12 @@ import com.cronutils.model.field.constraint.FieldConstraintsBuilder;
 import com.cronutils.model.field.expression.Between;
 import com.cronutils.model.field.expression.FieldExpression;
 import com.cronutils.model.field.value.IntegerFieldValue;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.mock;
 
 public class BetweenFieldValueGeneratorTest {
@@ -35,27 +35,27 @@ public class BetweenFieldValueGeneratorTest {
     private static final int TO = 2;
     private static final int OUT_OF_RANGE = 7;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         constraints = FieldConstraintsBuilder.instance().createConstraintsInstance();
         fieldValueGenerator = new BetweenFieldValueGenerator(
                 new CronField(CronFieldName.HOUR, new Between(new IntegerFieldValue(FROM), new IntegerFieldValue(TO)), constraints));
     }
 
-    @Test(expected = NoSuchValueException.class)
+    @Test
     public void testGenerateNextValue() throws NoSuchValueException {
         for (int j = FROM - 1; j < TO; j++) {
             assertEquals(j + 1L, fieldValueGenerator.generateNextValue(j));
         }
-        fieldValueGenerator.generateNextValue(TO);
+        assertThrows(NoSuchValueException.class, () -> fieldValueGenerator.generateNextValue(TO));
     }
 
-    @Test(expected = NoSuchValueException.class)
+    @Test
     public void testGeneratePreviousValue() throws NoSuchValueException {
         for (int j = TO + 1; j > FROM; j--) {
             assertEquals(j - 1L, fieldValueGenerator.generatePreviousValue(j));
         }
-        fieldValueGenerator.generatePreviousValue(FROM);
+        assertThrows(NoSuchValueException.class, () -> fieldValueGenerator.generatePreviousValue(FROM));
     }
 
     @Test
@@ -83,8 +83,8 @@ public class BetweenFieldValueGeneratorTest {
         assertFalse(fieldValueGenerator.matchesFieldExpressionClass(mock(FieldExpression.class)));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testConstructorNotMatchesBetween() {
-        new BetweenFieldValueGenerator(new CronField(CronFieldName.HOUR, mock(FieldExpression.class), constraints));
+        assertThrows(IllegalArgumentException.class, () -> new BetweenFieldValueGenerator(new CronField(CronFieldName.HOUR, mock(FieldExpression.class), constraints)));
     }
 }

--- a/src/test/java/com/cronutils/model/time/generator/BetweenFieldValueGeneratorTest.java
+++ b/src/test/java/com/cronutils/model/time/generator/BetweenFieldValueGeneratorTest.java
@@ -44,7 +44,7 @@ public class BetweenFieldValueGeneratorTest {
 
     @Test(expected = NoSuchValueException.class)
     public void testGenerateNextValue() throws NoSuchValueException {
-        for (int j = FROM - 1; j < (TO + 1); j++) {
+        for (int j = FROM - 1; j < TO; j++) {
             assertEquals(j + 1L, fieldValueGenerator.generateNextValue(j));
         }
         fieldValueGenerator.generateNextValue(TO);
@@ -52,7 +52,7 @@ public class BetweenFieldValueGeneratorTest {
 
     @Test(expected = NoSuchValueException.class)
     public void testGeneratePreviousValue() throws NoSuchValueException {
-        for (int j = TO + 1; j > (FROM - 1); j--) {
+        for (int j = TO + 1; j > FROM; j--) {
             assertEquals(j - 1L, fieldValueGenerator.generatePreviousValue(j));
         }
         fieldValueGenerator.generatePreviousValue(FROM);

--- a/src/test/java/com/cronutils/model/time/generator/EveryDayOfWeekValueGeneratorTest.java
+++ b/src/test/java/com/cronutils/model/time/generator/EveryDayOfWeekValueGeneratorTest.java
@@ -22,8 +22,8 @@ import com.cronutils.model.field.expression.Between;
 import com.cronutils.model.field.expression.Every;
 import com.cronutils.model.field.expression.FieldExpression;
 import com.cronutils.model.field.value.IntegerFieldValue;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.time.DayOfWeek;
 import java.time.LocalDate;
@@ -33,7 +33,7 @@ import java.util.EnumSet;
 import java.util.List;
 import java.util.Set;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.mock;
 
 public class EveryDayOfWeekValueGeneratorTest {
@@ -42,7 +42,7 @@ public class EveryDayOfWeekValueGeneratorTest {
     private int month = 10;
     private Set<DayOfWeek> validDow;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         FieldConstraints constraints = FieldConstraintsBuilder.instance().createConstraintsInstance();
         // every 2 days between 1-5

--- a/src/test/java/com/cronutils/model/time/generator/EveryFieldValueGeneratorTest.java
+++ b/src/test/java/com/cronutils/model/time/generator/EveryFieldValueGeneratorTest.java
@@ -20,13 +20,13 @@ import com.cronutils.model.field.constraint.FieldConstraintsBuilder;
 import com.cronutils.model.field.expression.Every;
 import com.cronutils.model.field.expression.FieldExpression;
 import com.cronutils.model.field.value.IntegerFieldValue;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 import java.util.Random;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.mock;
 
 public class EveryFieldValueGeneratorTest {
@@ -35,7 +35,7 @@ public class EveryFieldValueGeneratorTest {
 
     private static final int TIME = 7;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         constraints = FieldConstraintsBuilder.instance().createConstraintsInstance();
         fieldValueGenerator = new EveryFieldValueGenerator(new CronField(CronFieldName.HOUR, new Every(new IntegerFieldValue(TIME)), constraints));
@@ -78,8 +78,8 @@ public class EveryFieldValueGeneratorTest {
         assertFalse(fieldValueGenerator.matchesFieldExpressionClass(mock(FieldExpression.class)));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testConstructorNotMatchesEvery() {
-        new EveryFieldValueGenerator(new CronField(CronFieldName.HOUR, mock(FieldExpression.class), constraints));
+        assertThrows(IllegalArgumentException.class, () -> new EveryFieldValueGenerator(new CronField(CronFieldName.HOUR, mock(FieldExpression.class), constraints)));
     }
 }

--- a/src/test/java/com/cronutils/model/time/generator/ExecutionTimeUnixIntegrationTest.java
+++ b/src/test/java/com/cronutils/model/time/generator/ExecutionTimeUnixIntegrationTest.java
@@ -19,12 +19,12 @@ import com.cronutils.model.definition.CronDefinition;
 import com.cronutils.model.definition.CronDefinitionBuilder;
 import com.cronutils.model.time.ExecutionTime;
 import com.cronutils.parser.CronParser;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.time.*;
 import java.util.*;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class ExecutionTimeUnixIntegrationTest {
 

--- a/src/test/java/com/cronutils/model/time/generator/FieldValueGeneratorFactoryTest.java
+++ b/src/test/java/com/cronutils/model/time/generator/FieldValueGeneratorFactoryTest.java
@@ -20,18 +20,19 @@ import com.cronutils.model.field.expression.*;
 import com.cronutils.model.field.value.IntegerFieldValue;
 import com.cronutils.model.field.value.SpecialChar;
 import com.cronutils.model.field.value.SpecialCharFieldValue;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 public class FieldValueGeneratorFactoryTest {
     private CronField mockCronField;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         mockCronField = mock(CronField.class);
     }
@@ -75,7 +76,7 @@ public class FieldValueGeneratorFactoryTest {
                 } catch (final RuntimeException e) {
                     gotException = true;
                 }
-                assertTrue("Should get exception when asking for OnValueGenerator with special char", gotException);
+                assertTrue(gotException, "Should get exception when asking for OnValueGenerator with special char");
             }
         }
     }
@@ -134,14 +135,14 @@ public class FieldValueGeneratorFactoryTest {
         return FieldValueGeneratorFactory.createDayOfMonthValueGeneratorInstance(mockCronField, 2015, 1);
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testCreateDayOfMonthValueGeneratorInstanceBadCronFieldName() {
         when(mockCronField.getField()).thenReturn(CronFieldName.YEAR);
         final On mockOn = mock(On.class);
         when(mockOn.getSpecialChar()).thenReturn(new SpecialCharFieldValue(SpecialChar.L));//any value except NONE
         when(mockCronField.getExpression()).thenReturn(mockOn);
 
-        FieldValueGeneratorFactory.createDayOfMonthValueGeneratorInstance(mockCronField, 2015, 1);
+        assertThrows(IllegalArgumentException.class, () -> FieldValueGeneratorFactory.createDayOfMonthValueGeneratorInstance(mockCronField, 2015, 1));
     }
 
     @Test
@@ -175,10 +176,10 @@ public class FieldValueGeneratorFactoryTest {
         );
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testCreateDayOfWeekValueGeneratorInstanceBadCronFieldName() {
         when(mockCronField.getField()).thenReturn(CronFieldName.YEAR);
         when(mockCronField.getExpression()).thenReturn(mock(On.class));
-        FieldValueGeneratorFactory.createDayOfWeekValueGeneratorInstance(mockCronField, 2015, 1, new WeekDay(1, false));
+        assertThrows(IllegalArgumentException.class, () -> FieldValueGeneratorFactory.createDayOfWeekValueGeneratorInstance(mockCronField, 2015, 1, new WeekDay(1, false)));
     }
 }

--- a/src/test/java/com/cronutils/model/time/generator/FieldValueGeneratorTest.java
+++ b/src/test/java/com/cronutils/model/time/generator/FieldValueGeneratorTest.java
@@ -17,18 +17,18 @@ import com.cronutils.model.field.CronField;
 import com.cronutils.model.field.CronFieldName;
 import com.cronutils.model.field.constraint.FieldConstraints;
 import com.cronutils.model.field.expression.FieldExpression;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.mock;
 
 public class FieldValueGeneratorTest {
     private FieldValueGenerator fieldValueGenerator;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         fieldValueGenerator = new MockFieldValueGenerator(new CronField(CronFieldName.HOUR, mock(FieldExpression.class), mock(FieldConstraints.class)));
     }

--- a/src/test/java/com/cronutils/model/time/generator/NullFieldValueGeneratorTest.java
+++ b/src/test/java/com/cronutils/model/time/generator/NullFieldValueGeneratorTest.java
@@ -15,32 +15,32 @@ package com.cronutils.model.time.generator;
 
 import com.cronutils.model.field.CronField;
 import com.cronutils.model.field.expression.FieldExpression;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.Random;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.mock;
 
 public class NullFieldValueGeneratorTest {
     private NullFieldValueGenerator fieldValueGenerator;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         fieldValueGenerator = new NullFieldValueGenerator(mock(CronField.class));
     }
 
-    @Test(expected = NoSuchValueException.class)
-    public void testGenerateNextValue() throws NoSuchValueException {
+    @Test
+    public void testGenerateNextValue() {
         final Random random = new Random();
-        fieldValueGenerator.generateNextValue(random.nextInt(10));
+        assertThrows(NoSuchValueException.class, () -> fieldValueGenerator.generateNextValue(random.nextInt(10)));
     }
 
-    @Test(expected = NoSuchValueException.class)
-    public void testGeneratePreviousValue() throws NoSuchValueException {
+    @Test
+    public void testGeneratePreviousValue() {
         final Random random = new Random();
-        fieldValueGenerator.generatePreviousValue(random.nextInt(10));
+        assertThrows(NoSuchValueException.class, () -> fieldValueGenerator.generatePreviousValue(random.nextInt(10)));
     }
 
     @Test

--- a/src/test/java/com/cronutils/model/time/generator/OnDayOfMonthValueGeneratorLTest.java
+++ b/src/test/java/com/cronutils/model/time/generator/OnDayOfMonthValueGeneratorLTest.java
@@ -20,13 +20,13 @@ import com.cronutils.model.field.constraint.FieldConstraintsBuilder;
 import com.cronutils.model.field.expression.On;
 import com.cronutils.model.field.value.SpecialChar;
 import com.cronutils.model.field.value.SpecialCharFieldValue;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.time.LocalDate;
 import java.util.List;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class OnDayOfMonthValueGeneratorLTest {
     private OnDayOfMonthValueGenerator fieldValueGenerator;
@@ -34,23 +34,23 @@ public class OnDayOfMonthValueGeneratorLTest {
     private static final int MONTH = 2;
     private final int lastDayInMonth = LocalDate.of(2015, 2, 1).lengthOfMonth();
 
-    @Before
+    @BeforeEach
     public void setUp() {
         final FieldConstraints constraints = FieldConstraintsBuilder.instance().addLSupport().createConstraintsInstance();
         fieldValueGenerator = new OnDayOfMonthValueGenerator(
                 new CronField(CronFieldName.DAY_OF_MONTH, new On(new SpecialCharFieldValue(SpecialChar.L)), constraints), YEAR, MONTH);
     }
 
-    @Test(expected = NoSuchValueException.class)
+    @Test
     public void testGenerateNextValue() throws NoSuchValueException {
         assertEquals(lastDayInMonth, fieldValueGenerator.generateNextValue(1));
-        fieldValueGenerator.generateNextValue(lastDayInMonth);
+        assertThrows(NoSuchValueException.class, () -> fieldValueGenerator.generateNextValue(lastDayInMonth));
     }
 
-    @Test(expected = NoSuchValueException.class)
+    @Test
     public void testGeneratePreviousValue() throws NoSuchValueException {
         assertEquals(lastDayInMonth, fieldValueGenerator.generatePreviousValue(lastDayInMonth + 1));
-        fieldValueGenerator.generatePreviousValue(lastDayInMonth);
+        assertThrows(NoSuchValueException.class, () -> fieldValueGenerator.generatePreviousValue(lastDayInMonth));
     }
 
     @Test

--- a/src/test/java/com/cronutils/model/time/generator/OnDayOfMonthValueGeneratorLWTest.java
+++ b/src/test/java/com/cronutils/model/time/generator/OnDayOfMonthValueGeneratorLWTest.java
@@ -20,12 +20,12 @@ import com.cronutils.model.field.constraint.FieldConstraintsBuilder;
 import com.cronutils.model.field.expression.On;
 import com.cronutils.model.field.value.SpecialChar;
 import com.cronutils.model.field.value.SpecialCharFieldValue;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class OnDayOfMonthValueGeneratorLWTest {
     private FieldConstraints constraints;
@@ -43,39 +43,39 @@ public class OnDayOfMonthValueGeneratorLWTest {
 
     private static final int OUT_OF_SCOPE_VALUE = 31;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         constraints = FieldConstraintsBuilder.instance().addLWSupport().createConstraintsInstance();
     }
 
-    @Test(expected = NoSuchValueException.class)
-    public void testGenerateNextValueSundayValue() throws NoSuchValueException {
-        testGenerateNextValue(SUNDAY_VALUE_MONTH, SUNDAY_VALUE_WEEKDAY);
+    @Test
+    public void testGenerateNextValueSundayValue() {
+        assertThrows(NoSuchValueException.class, () -> testGenerateNextValue(SUNDAY_VALUE_MONTH, SUNDAY_VALUE_WEEKDAY));
     }
 
-    @Test(expected = NoSuchValueException.class)
-    public void testGenerateNextValueSaturdayValue() throws NoSuchValueException {
-        testGenerateNextValue(SATURDAY_VALUE_MONTH, SATURDAY_VALUE_WEEKDAY);
+    @Test
+    public void testGenerateNextValueSaturdayValue() {
+        assertThrows(NoSuchValueException.class, () -> testGenerateNextValue(SATURDAY_VALUE_MONTH, SATURDAY_VALUE_WEEKDAY));
     }
 
-    @Test(expected = NoSuchValueException.class)
-    public void testGenerateNextValueFridayValue() throws NoSuchValueException {
-        testGenerateNextValue(FRIDAY_VALUE_MONTH, FRIDAY_VALUE_WEEKDAY);
+    @Test
+    public void testGenerateNextValueFridayValue() {
+        assertThrows(NoSuchValueException.class, () -> testGenerateNextValue(FRIDAY_VALUE_MONTH, FRIDAY_VALUE_WEEKDAY));
     }
 
-    @Test(expected = NoSuchValueException.class)
-    public void testGeneratePreviousValueSundayValue() throws NoSuchValueException {
-        testGeneratePreviousValue(SUNDAY_VALUE_MONTH, SUNDAY_VALUE_WEEKDAY);
+    @Test
+    public void testGeneratePreviousValueSundayValue() {
+        assertThrows(NoSuchValueException.class, () -> testGeneratePreviousValue(SUNDAY_VALUE_MONTH, SUNDAY_VALUE_WEEKDAY));
     }
 
-    @Test(expected = NoSuchValueException.class)
-    public void testGeneratePreviousValueSaturdayValue() throws NoSuchValueException {
-        testGeneratePreviousValue(SATURDAY_VALUE_MONTH, SATURDAY_VALUE_WEEKDAY);
+    @Test
+    public void testGeneratePreviousValueSaturdayValue() {
+        assertThrows(NoSuchValueException.class, () -> testGeneratePreviousValue(SATURDAY_VALUE_MONTH, SATURDAY_VALUE_WEEKDAY));
     }
 
-    @Test(expected = NoSuchValueException.class)
-    public void testGeneratePreviousValueFridayValue() throws NoSuchValueException {
-        testGeneratePreviousValue(FRIDAY_VALUE_MONTH, FRIDAY_VALUE_WEEKDAY);
+    @Test
+    public void testGeneratePreviousValueFridayValue() {
+        assertThrows(NoSuchValueException.class, () -> testGeneratePreviousValue(FRIDAY_VALUE_MONTH, FRIDAY_VALUE_WEEKDAY));
     }
 
     @Test

--- a/src/test/java/com/cronutils/model/time/generator/OnDayOfMonthValueGeneratorTest.java
+++ b/src/test/java/com/cronutils/model/time/generator/OnDayOfMonthValueGeneratorTest.java
@@ -20,13 +20,14 @@ import com.cronutils.model.field.constraint.FieldConstraintsBuilder;
 import com.cronutils.model.field.expression.FieldExpression;
 import com.cronutils.model.field.expression.On;
 import com.cronutils.model.field.value.IntegerFieldValue;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.Random;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 
 public class OnDayOfMonthValueGeneratorTest {
@@ -36,7 +37,7 @@ public class OnDayOfMonthValueGeneratorTest {
     private static final int MONTH = 2;
     private final Random random = new Random();
 
-    @Before
+    @BeforeEach
     public void setUp() {
         constraints = FieldConstraintsBuilder.instance().createConstraintsInstance();
         fieldValueGenerator =
@@ -47,14 +48,14 @@ public class OnDayOfMonthValueGeneratorTest {
                         YEAR, MONTH);
     }
 
-    @Test(expected = NoSuchValueException.class)
-    public void testGenerateNextValue() throws NoSuchValueException {
-        fieldValueGenerator.generateNextValue(randomNumber());
+    @Test
+    public void testGenerateNextValue() {
+        assertThrows(NoSuchValueException.class, () -> fieldValueGenerator.generateNextValue(randomNumber()));
     }
 
-    @Test(expected = NoSuchValueException.class)
-    public void testGeneratePreviousValue() throws NoSuchValueException {
-        fieldValueGenerator.generatePreviousValue(randomNumber());
+    @Test
+    public void testGeneratePreviousValue() {
+        assertThrows(NoSuchValueException.class, () -> fieldValueGenerator.generatePreviousValue(randomNumber()));
     }
 
     @Test
@@ -63,9 +64,9 @@ public class OnDayOfMonthValueGeneratorTest {
         assertFalse(fieldValueGenerator.matchesFieldExpressionClass(mock(FieldExpression.class)));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testConstructorNotMatchesOn() {
-        new OnDayOfMonthValueGenerator(new CronField(CronFieldName.YEAR, mock(FieldExpression.class), constraints), YEAR, MONTH);
+        assertThrows(IllegalArgumentException.class, () -> new OnDayOfMonthValueGenerator(new CronField(CronFieldName.YEAR, mock(FieldExpression.class), constraints), YEAR, MONTH));
     }
 
     private int randomNumber() {

--- a/src/test/java/com/cronutils/model/time/generator/OnDayOfMonthValueGeneratorWTest.java
+++ b/src/test/java/com/cronutils/model/time/generator/OnDayOfMonthValueGeneratorWTest.java
@@ -21,12 +21,12 @@ import com.cronutils.model.field.expression.On;
 import com.cronutils.model.field.value.IntegerFieldValue;
 import com.cronutils.model.field.value.SpecialChar;
 import com.cronutils.model.field.value.SpecialCharFieldValue;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class OnDayOfMonthValueGeneratorWTest {
     private FieldConstraints constraints;
@@ -46,39 +46,39 @@ public class OnDayOfMonthValueGeneratorWTest {
 
     private static final int OUT_OF_SCOPE_VALUE = 18;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         constraints = FieldConstraintsBuilder.instance().addWSupport().createConstraintsInstance();
     }
 
-    @Test(expected = NoSuchValueException.class)
-    public void testGenerateNextValueSundayValue() throws NoSuchValueException {
-        testGenerateNextValue(SUNDAY_VALUE_MONTH, SUNDAY_VALUE_DAY, SUNDAY_VALUE_WEEKDAY);
+    @Test
+    public void testGenerateNextValueSundayValue() {
+        assertThrows(NoSuchValueException.class, () -> testGenerateNextValue(SUNDAY_VALUE_MONTH, SUNDAY_VALUE_DAY, SUNDAY_VALUE_WEEKDAY));
     }
 
-    @Test(expected = NoSuchValueException.class)
-    public void testGenerateNextValueSaturdayValue() throws NoSuchValueException {
-        testGenerateNextValue(SATURDAY_VALUE_MONTH, SATURDAY_VALUE_DAY, SATURDAY_VALUE_WEEKDAY);
+    @Test
+    public void testGenerateNextValueSaturdayValue() {
+        assertThrows(NoSuchValueException.class, () -> testGenerateNextValue(SATURDAY_VALUE_MONTH, SATURDAY_VALUE_DAY, SATURDAY_VALUE_WEEKDAY));
     }
 
-    @Test(expected = NoSuchValueException.class)
-    public void testGenerateNextValueFirstDaySaturdayValue() throws NoSuchValueException {
-        testGenerateNextValue(FIRST_DAY_SATURDAY_VALUE_MONTH, FIRST_DAY_SATURDAY_VALUE_DAY, FIRST_DAY_SATURDAY_VALUE_WEEKDAY);
+    @Test
+    public void testGenerateNextValueFirstDaySaturdayValue() {
+        assertThrows(NoSuchValueException.class, () -> testGenerateNextValue(FIRST_DAY_SATURDAY_VALUE_MONTH, FIRST_DAY_SATURDAY_VALUE_DAY, FIRST_DAY_SATURDAY_VALUE_WEEKDAY));
     }
 
-    @Test(expected = NoSuchValueException.class)
-    public void testGeneratePreviousValueSundayValue() throws NoSuchValueException {
-        testGeneratePreviousValue(SUNDAY_VALUE_MONTH, SUNDAY_VALUE_DAY, SUNDAY_VALUE_WEEKDAY);
+    @Test
+    public void testGeneratePreviousValueSundayValue() {
+        assertThrows(NoSuchValueException.class, () -> testGeneratePreviousValue(SUNDAY_VALUE_MONTH, SUNDAY_VALUE_DAY, SUNDAY_VALUE_WEEKDAY));
     }
 
-    @Test(expected = NoSuchValueException.class)
-    public void testGeneratePreviousValueSaturdayValue() throws NoSuchValueException {
-        testGeneratePreviousValue(SATURDAY_VALUE_MONTH, SATURDAY_VALUE_DAY, SATURDAY_VALUE_WEEKDAY);
+    @Test
+    public void testGeneratePreviousValueSaturdayValue() {
+        assertThrows(NoSuchValueException.class, () -> testGeneratePreviousValue(SATURDAY_VALUE_MONTH, SATURDAY_VALUE_DAY, SATURDAY_VALUE_WEEKDAY));
     }
 
-    @Test(expected = NoSuchValueException.class)
-    public void testGeneratePreviousValueFirstDaySaturdayValue() throws NoSuchValueException {
-        testGeneratePreviousValue(FIRST_DAY_SATURDAY_VALUE_MONTH, FIRST_DAY_SATURDAY_VALUE_DAY, FIRST_DAY_SATURDAY_VALUE_WEEKDAY);
+    @Test
+    public void testGeneratePreviousValueFirstDaySaturdayValue() {
+        assertThrows(NoSuchValueException.class, () -> testGeneratePreviousValue(FIRST_DAY_SATURDAY_VALUE_MONTH, FIRST_DAY_SATURDAY_VALUE_DAY, FIRST_DAY_SATURDAY_VALUE_WEEKDAY));
     }
 
     @Test

--- a/src/test/java/com/cronutils/model/time/generator/OnDayOfWeekValueGeneratorHashTest.java
+++ b/src/test/java/com/cronutils/model/time/generator/OnDayOfWeekValueGeneratorHashTest.java
@@ -23,11 +23,11 @@ import com.cronutils.model.field.expression.On;
 import com.cronutils.model.field.value.IntegerFieldValue;
 import com.cronutils.model.field.value.SpecialChar;
 import com.cronutils.model.field.value.SpecialCharFieldValue;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class OnDayOfWeekValueGeneratorHashTest {
     FieldConstraints constraints = FieldConstraintsBuilder.instance().addHashSupport().createConstraintsInstance();
@@ -50,46 +50,46 @@ public class OnDayOfWeekValueGeneratorHashTest {
     private static final int FIRST_DAY_DOW_EQUALTO_REQUESTED_DOW_HASHVALUE = 3;
     private static final int FIRST_DAY_DOW_EQUALTO_REQUESTED_DOW_DAY = 15;//3rd Sunday of month (1#3) is 15
 
-    @Test(expected = NoSuchValueException.class)
+    @Test
     public void testGenerateNextValueLastDayDoWGreaterThanRequestedDoW() throws NoSuchValueException {
         fieldValueGenerator = createFieldValueGeneratorInstanceFirstDayDoWGreaterThanRequestedDoW();
         assertEquals(FIRST_DAY_DOW_GREATER_THAN_REQUESTED_DOW_DAY, fieldValueGenerator.generateNextValue(1));
-        fieldValueGenerator.generateNextValue(FIRST_DAY_DOW_GREATER_THAN_REQUESTED_DOW_DAY);
+        assertThrows(NoSuchValueException.class, () -> fieldValueGenerator.generateNextValue(FIRST_DAY_DOW_GREATER_THAN_REQUESTED_DOW_DAY));
     }
 
-    @Test(expected = NoSuchValueException.class)
+    @Test
     public void testGenerateNextValueLastDayDoWLessThanRequestedDoW() throws NoSuchValueException {
         fieldValueGenerator = createFieldValueGeneratorInstanceLastDayDoWLessThanRequestedDoW();
         assertEquals(FIRST_DAY_DOW_LESS_THAN_REQUESTED_DOW_DAY, fieldValueGenerator.generateNextValue(1));
-        fieldValueGenerator.generateNextValue(FIRST_DAY_DOW_LESS_THAN_REQUESTED_DOW_DAY);
+        assertThrows(NoSuchValueException.class, () -> fieldValueGenerator.generateNextValue(FIRST_DAY_DOW_LESS_THAN_REQUESTED_DOW_DAY));
     }
 
-    @Test(expected = NoSuchValueException.class)
+    @Test
     public void testGenerateNextValueLastDayDoWEqualToRequestedDoW() throws NoSuchValueException {
         fieldValueGenerator = createFieldValueGeneratorInstanceLastDayDoWEqualToRequestedDoW();
         assertEquals(FIRST_DAY_DOW_EQUALTO_REQUESTED_DOW_DAY, fieldValueGenerator.generateNextValue(1));
-        fieldValueGenerator.generateNextValue(FIRST_DAY_DOW_EQUALTO_REQUESTED_DOW_DAY);
+        assertThrows(NoSuchValueException.class, () -> fieldValueGenerator.generateNextValue(FIRST_DAY_DOW_EQUALTO_REQUESTED_DOW_DAY));
     }
 
-    @Test(expected = NoSuchValueException.class)
+    @Test
     public void testGeneratePreviousValueLastDayDoWGreaterThanRequestedDoW() throws NoSuchValueException {
         fieldValueGenerator = createFieldValueGeneratorInstanceFirstDayDoWGreaterThanRequestedDoW();
         assertEquals(FIRST_DAY_DOW_GREATER_THAN_REQUESTED_DOW_DAY, fieldValueGenerator.generatePreviousValue(FIRST_DAY_DOW_GREATER_THAN_REQUESTED_DOW_DAY + 1));
-        fieldValueGenerator.generatePreviousValue(FIRST_DAY_DOW_GREATER_THAN_REQUESTED_DOW_DAY);
+        assertThrows(NoSuchValueException.class, () -> fieldValueGenerator.generatePreviousValue(FIRST_DAY_DOW_GREATER_THAN_REQUESTED_DOW_DAY));
     }
 
-    @Test(expected = NoSuchValueException.class)
+    @Test
     public void testGeneratePreviousValueLastDayDoWLessThanRequestedDoW() throws NoSuchValueException {
         fieldValueGenerator = createFieldValueGeneratorInstanceLastDayDoWLessThanRequestedDoW();
         assertEquals(FIRST_DAY_DOW_LESS_THAN_REQUESTED_DOW_DAY, fieldValueGenerator.generatePreviousValue(FIRST_DAY_DOW_LESS_THAN_REQUESTED_DOW_DAY + 1));
-        fieldValueGenerator.generatePreviousValue(FIRST_DAY_DOW_LESS_THAN_REQUESTED_DOW_DAY);
+        assertThrows(NoSuchValueException.class, () -> fieldValueGenerator.generatePreviousValue(FIRST_DAY_DOW_LESS_THAN_REQUESTED_DOW_DAY));
     }
 
-    @Test(expected = NoSuchValueException.class)
+    @Test
     public void testGeneratePreviousValueLastDayDoWEqualToRequestedDoW() throws NoSuchValueException {
         fieldValueGenerator = createFieldValueGeneratorInstanceLastDayDoWEqualToRequestedDoW();
         assertEquals(FIRST_DAY_DOW_EQUALTO_REQUESTED_DOW_DAY, fieldValueGenerator.generatePreviousValue(FIRST_DAY_DOW_EQUALTO_REQUESTED_DOW_DAY + 1));
-        fieldValueGenerator.generatePreviousValue(FIRST_DAY_DOW_EQUALTO_REQUESTED_DOW_DAY);
+        assertThrows(NoSuchValueException.class, () -> fieldValueGenerator.generatePreviousValue(FIRST_DAY_DOW_EQUALTO_REQUESTED_DOW_DAY));
     }
 
     @Test

--- a/src/test/java/com/cronutils/model/time/generator/OnDayOfWeekValueGeneratorLTest.java
+++ b/src/test/java/com/cronutils/model/time/generator/OnDayOfWeekValueGeneratorLTest.java
@@ -23,11 +23,11 @@ import com.cronutils.model.field.expression.On;
 import com.cronutils.model.field.value.IntegerFieldValue;
 import com.cronutils.model.field.value.SpecialChar;
 import com.cronutils.model.field.value.SpecialCharFieldValue;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class OnDayOfWeekValueGeneratorLTest {
     private final FieldConstraints constraints = FieldConstraintsBuilder.instance().addLSupport().createConstraintsInstance();
@@ -47,46 +47,46 @@ public class OnDayOfWeekValueGeneratorLTest {
     private static final int LAST_DAY_DOW_EQUALTO_REQUESTED_DOW_VALUE = 6;
     private static final int LAST_DAY_DOW_EQUALTO_REQUESTED_DOW_DAY = 31;
 
-    @Test(expected = NoSuchValueException.class)
+    @Test
     public void testGenerateNextValueLastDayDoWGreaterThanRequestedDoW() throws NoSuchValueException {
         fieldValueGenerator = createFieldValueGeneratorInstanceLastDayDoWGreaterThanRequestedDoW();
         assertEquals(LAST_DAY_DOW_GREATER_THAN_REQUESTED_DOW_DAY, fieldValueGenerator.generateNextValue(1));
-        fieldValueGenerator.generateNextValue(LAST_DAY_DOW_GREATER_THAN_REQUESTED_DOW_DAY);
+        assertThrows(NoSuchValueException.class, () -> fieldValueGenerator.generateNextValue(LAST_DAY_DOW_GREATER_THAN_REQUESTED_DOW_DAY));
     }
 
-    @Test(expected = NoSuchValueException.class)
+    @Test
     public void testGenerateNextValueLastDayDoWLessThanRequestedDoW() throws NoSuchValueException {
         fieldValueGenerator = createFieldValueGeneratorInstanceLastDayDoWLessThanRequestedDoW();
         assertEquals(LAST_DAY_DOW_LESS_THAN_REQUESTED_DOW_DAY, fieldValueGenerator.generateNextValue(1));
-        fieldValueGenerator.generateNextValue(LAST_DAY_DOW_LESS_THAN_REQUESTED_DOW_DAY);
+        assertThrows(NoSuchValueException.class, () -> fieldValueGenerator.generateNextValue(LAST_DAY_DOW_LESS_THAN_REQUESTED_DOW_DAY));
     }
 
-    @Test(expected = NoSuchValueException.class)
+    @Test
     public void testGenerateNextValueLastDayDoWEqualToRequestedDoW() throws NoSuchValueException {
         fieldValueGenerator = createFieldValueGeneratorInstanceLastDayDoWEqualToRequestedDoW();
         assertEquals(LAST_DAY_DOW_EQUALTO_REQUESTED_DOW_DAY, fieldValueGenerator.generateNextValue(1));
-        fieldValueGenerator.generateNextValue(LAST_DAY_DOW_EQUALTO_REQUESTED_DOW_DAY);
+        assertThrows(NoSuchValueException.class, () -> fieldValueGenerator.generateNextValue(LAST_DAY_DOW_EQUALTO_REQUESTED_DOW_DAY));
     }
 
-    @Test(expected = NoSuchValueException.class)
+    @Test
     public void testGeneratePreviousValueLastDayDoWGreaterThanRequestedDoW() throws NoSuchValueException {
         fieldValueGenerator = createFieldValueGeneratorInstanceLastDayDoWGreaterThanRequestedDoW();
         assertEquals(LAST_DAY_DOW_GREATER_THAN_REQUESTED_DOW_DAY, fieldValueGenerator.generatePreviousValue(LAST_DAY_DOW_GREATER_THAN_REQUESTED_DOW_DAY + 1));
-        fieldValueGenerator.generatePreviousValue(LAST_DAY_DOW_GREATER_THAN_REQUESTED_DOW_DAY);
+        assertThrows(NoSuchValueException.class, () -> fieldValueGenerator.generatePreviousValue(LAST_DAY_DOW_GREATER_THAN_REQUESTED_DOW_DAY));
     }
 
-    @Test(expected = NoSuchValueException.class)
+    @Test
     public void testGeneratePreviousValueLastDayDoWLessThanRequestedDoW() throws NoSuchValueException {
         fieldValueGenerator = createFieldValueGeneratorInstanceLastDayDoWLessThanRequestedDoW();
         assertEquals(LAST_DAY_DOW_LESS_THAN_REQUESTED_DOW_DAY, fieldValueGenerator.generatePreviousValue(LAST_DAY_DOW_LESS_THAN_REQUESTED_DOW_DAY + 1));
-        fieldValueGenerator.generatePreviousValue(LAST_DAY_DOW_LESS_THAN_REQUESTED_DOW_DAY);
+        assertThrows(NoSuchValueException.class, () -> fieldValueGenerator.generatePreviousValue(LAST_DAY_DOW_LESS_THAN_REQUESTED_DOW_DAY));
     }
 
-    @Test(expected = NoSuchValueException.class)
+    @Test
     public void testGeneratePreviousValueLastDayDoWEqualToRequestedDoW() throws NoSuchValueException {
         fieldValueGenerator = createFieldValueGeneratorInstanceLastDayDoWEqualToRequestedDoW();
         assertEquals(LAST_DAY_DOW_EQUALTO_REQUESTED_DOW_DAY, fieldValueGenerator.generatePreviousValue(LAST_DAY_DOW_EQUALTO_REQUESTED_DOW_DAY + 1));
-        fieldValueGenerator.generatePreviousValue(LAST_DAY_DOW_EQUALTO_REQUESTED_DOW_DAY);
+        assertThrows(NoSuchValueException.class, () -> fieldValueGenerator.generatePreviousValue(LAST_DAY_DOW_EQUALTO_REQUESTED_DOW_DAY));
     }
 
     @Test

--- a/src/test/java/com/cronutils/model/time/generator/OnDayOfWeekValueGeneratorTest.java
+++ b/src/test/java/com/cronutils/model/time/generator/OnDayOfWeekValueGeneratorTest.java
@@ -21,11 +21,12 @@ import com.cronutils.model.field.constraint.FieldConstraintsBuilder;
 import com.cronutils.model.field.expression.FieldExpression;
 import com.cronutils.model.field.expression.On;
 import com.cronutils.model.field.value.IntegerFieldValue;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 
 public class OnDayOfWeekValueGeneratorTest {
@@ -35,7 +36,7 @@ public class OnDayOfWeekValueGeneratorTest {
     private static final int YEAR = 2015;
     private static final int MONTH = 2;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         constraints = FieldConstraintsBuilder.instance().createConstraintsInstance();
         mondayDoWValue = new WeekDay(1, false);
@@ -49,8 +50,8 @@ public class OnDayOfWeekValueGeneratorTest {
         assertFalse(fieldValueGenerator.matchesFieldExpressionClass(mock(FieldExpression.class)));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testConstructorNotMatchesOnDayOfWeekValueGenerator() {
-        new OnDayOfWeekValueGenerator(new CronField(CronFieldName.YEAR, mock(FieldExpression.class), constraints), YEAR, MONTH, mondayDoWValue);
+        assertThrows(IllegalArgumentException.class, () -> new OnDayOfWeekValueGenerator(new CronField(CronFieldName.YEAR, mock(FieldExpression.class), constraints), YEAR, MONTH, mondayDoWValue));
     }
 }

--- a/src/test/java/com/cronutils/model/time/generator/OnFieldValueGeneratorTest.java
+++ b/src/test/java/com/cronutils/model/time/generator/OnFieldValueGeneratorTest.java
@@ -19,19 +19,19 @@ import com.cronutils.model.field.constraint.FieldConstraintsBuilder;
 import com.cronutils.model.field.expression.FieldExpression;
 import com.cronutils.model.field.expression.On;
 import com.cronutils.model.field.value.IntegerFieldValue;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.mock;
 
 public class OnFieldValueGeneratorTest {
     private OnFieldValueGenerator fieldValueGenerator;
     private static final int DAY = 3;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         fieldValueGenerator =
                 new OnFieldValueGenerator(
@@ -43,16 +43,16 @@ public class OnFieldValueGeneratorTest {
                 );
     }
 
-    @Test(expected = NoSuchValueException.class)
+    @Test
     public void testGenerateNextValue() throws NoSuchValueException {
         assertEquals(DAY, fieldValueGenerator.generateNextValue(1));
-        fieldValueGenerator.generateNextValue(DAY);
+        assertThrows(NoSuchValueException.class, () -> fieldValueGenerator.generateNextValue(DAY));
     }
 
-    @Test(expected = NoSuchValueException.class)
+    @Test
     public void testGeneratePreviousValue() throws NoSuchValueException {
         assertEquals(DAY, fieldValueGenerator.generatePreviousValue(DAY + 1));
-        fieldValueGenerator.generatePreviousValue(DAY);
+        assertThrows(NoSuchValueException.class, () -> fieldValueGenerator.generatePreviousValue(DAY));
     }
 
     @Test
@@ -74,8 +74,8 @@ public class OnFieldValueGeneratorTest {
         assertFalse(fieldValueGenerator.matchesFieldExpressionClass(mock(FieldExpression.class)));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testConstructorNotMatchesOn() {
-        new OnFieldValueGenerator(mock(CronField.class));
+        assertThrows(IllegalArgumentException.class, () -> new OnFieldValueGenerator(mock(CronField.class)));
     }
 }

--- a/src/test/java/com/cronutils/parser/CronParserCron4JIntegrationTest.java
+++ b/src/test/java/com/cronutils/parser/CronParserCron4JIntegrationTest.java
@@ -17,16 +17,16 @@ import com.cronutils.model.Cron;
 import com.cronutils.model.CronType;
 import com.cronutils.model.definition.CronDefinition;
 import com.cronutils.model.definition.CronDefinitionBuilder;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class CronParserCron4JIntegrationTest {
     private CronParser cron4jParser;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         final CronDefinition cronDefinition = CronDefinitionBuilder.instanceDefinitionFor(CronType.CRON4J);
         cron4jParser = new CronParser(cronDefinition);
@@ -50,17 +50,17 @@ public class CronParserCron4JIntegrationTest {
         cron4jParser.parse(cronExpr);
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testParseStrictRangeEnforced02() {
         final String cronExpr = "* 1 5-2 * 4";
-        cron4jParser.parse(cronExpr);
+        assertThrows(IllegalArgumentException.class, () -> cron4jParser.parse(cronExpr));
     }
 
     @Test
     public void testParseLastDayOfMonth() {
         final String cronExpr = "* * L * *";
         final Cron cron = cron4jParser.parse(cronExpr);
-        assertThat(cron.asString(), is("* * L * *"));
+        assertEquals("* * L * *", cron.asString());
     }
 
     @Test //issue 202

--- a/src/test/java/com/cronutils/parser/CronParserFieldTest.java
+++ b/src/test/java/com/cronutils/parser/CronParserFieldTest.java
@@ -18,7 +18,6 @@ import com.cronutils.model.field.CronFieldName;
 import com.cronutils.model.field.constraint.FieldConstraints;
 import com.cronutils.model.field.expression.FieldExpression;
 import org.junit.After;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
@@ -29,6 +28,8 @@ import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 
 import java.util.UUID;
+
+import static org.junit.Assert.assertEquals;
 
 @Ignore
 public class CronParserFieldTest {
@@ -63,15 +64,15 @@ public class CronParserFieldTest {
 
     @Test
     public void testGetField() {
-        Assert.assertEquals(testFieldName, cronParserField.getField());
+        assertEquals(testFieldName, cronParserField.getField());
     }
 
     @Test
     public void testParse() {
         final String cron = UUID.randomUUID().toString();
         final CronField result = cronParserField.parse(cron);
-        Assert.assertEquals(mockParseResponse, result.getExpression());
-        Assert.assertEquals(testFieldName, result.getField());
+        assertEquals(mockParseResponse, result.getExpression());
+        assertEquals(testFieldName, result.getField());
         Mockito.verify(mockParser).parse(cron);
     }
 
@@ -82,8 +83,8 @@ public class CronParserFieldTest {
         Mockito.when(mockConstraints.getStringMappingValue("1")).thenReturn(null);
 
         final CronField result = cronParserField.parse("1L");
-        Assert.assertEquals(mockParseResponse, result.getExpression());
-        Assert.assertEquals(CronFieldName.DAY_OF_WEEK, result.getField());
+        assertEquals(mockParseResponse, result.getExpression());
+        assertEquals(CronFieldName.DAY_OF_WEEK, result.getField());
 
         Mockito.verify(mockConstraints).getStringMappingValue("1");
         Mockito.verify(mockParser).parse("1L");
@@ -96,8 +97,8 @@ public class CronParserFieldTest {
         Mockito.when(mockConstraints.getStringMappingValue("MON")).thenReturn(1);
 
         final CronField result = cronParserField.parse("MONL");
-        Assert.assertEquals(mockParseResponse, result.getExpression());
-        Assert.assertEquals(CronFieldName.DAY_OF_WEEK, result.getField());
+        assertEquals(mockParseResponse, result.getExpression());
+        assertEquals(CronFieldName.DAY_OF_WEEK, result.getField());
 
         Mockito.verify(mockConstraints).getStringMappingValue("MON");
         Mockito.verify(mockParser).parse("1L");

--- a/src/test/java/com/cronutils/parser/CronParserFieldTest.java
+++ b/src/test/java/com/cronutils/parser/CronParserFieldTest.java
@@ -17,10 +17,10 @@ import com.cronutils.model.field.CronField;
 import com.cronutils.model.field.CronFieldName;
 import com.cronutils.model.field.constraint.FieldConstraints;
 import com.cronutils.model.field.expression.FieldExpression;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 import org.mockito.Matchers;
 import org.mockito.Mock;
 import org.mockito.MockedConstruction;
@@ -29,9 +29,10 @@ import org.mockito.MockitoAnnotations;
 
 import java.util.UUID;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
-@Ignore
+@Disabled
 public class CronParserFieldTest {
 
     private CronFieldName testFieldName;
@@ -44,7 +45,7 @@ public class CronParserFieldTest {
 
     private CronParserField cronParserField;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         MockitoAnnotations.initMocks(this);
         testFieldName = CronFieldName.SECOND;
@@ -57,7 +58,7 @@ public class CronParserFieldTest {
         cronParserField = new CronParserField(testFieldName, mockConstraints);
     }
 
-    @After
+    @AfterEach
     public void tearDown() {
         mockedConstruction.close();
     }
@@ -104,13 +105,13 @@ public class CronParserFieldTest {
         Mockito.verify(mockParser).parse("1L");
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void testConstructorNameNull() {
-        new CronParserField(null, Mockito.mock(FieldConstraints.class));
+        assertThrows(NullPointerException.class, () -> new CronParserField(null, Mockito.mock(FieldConstraints.class)));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void testConstructorConstraintsNull() {
-        new CronParserField(testFieldName, null);
+        assertThrows(NullPointerException.class, () -> new CronParserField(testFieldName, null));
     }
 }

--- a/src/test/java/com/cronutils/parser/CronParserFieldTest.java
+++ b/src/test/java/com/cronutils/parser/CronParserFieldTest.java
@@ -17,31 +17,27 @@ import com.cronutils.model.field.CronField;
 import com.cronutils.model.field.CronFieldName;
 import com.cronutils.model.field.constraint.FieldConstraints;
 import com.cronutils.model.field.expression.FieldExpression;
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
-import org.junit.runner.RunWith;
 import org.mockito.Matchers;
 import org.mockito.Mock;
+import org.mockito.MockedConstruction;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
-import org.powermock.api.mockito.PowerMockito;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
 
 import java.util.UUID;
 
 @Ignore
-@RunWith(PowerMockRunner.class)
-@PrepareForTest({ CronParserField.class, CronParser.class })
 public class CronParserFieldTest {
 
     private CronFieldName testFieldName;
     @Mock
     private FieldConstraints mockConstraints;
-    @Mock
     private FieldParser mockParser;
+    private MockedConstruction<FieldParser> mockedConstruction;
     @Mock
     private FieldExpression mockParseResponse;
 
@@ -52,11 +48,17 @@ public class CronParserFieldTest {
         MockitoAnnotations.initMocks(this);
         testFieldName = CronFieldName.SECOND;
 
-        Mockito.when(mockParser.parse(Matchers.anyString())).thenReturn(mockParseResponse);
-        PowerMockito.whenNew(FieldParser.class)
-                .withArguments(Matchers.any(FieldConstraints.class)).thenReturn(mockParser);
+        mockedConstruction = Mockito.mockConstruction(FieldParser.class, (mock, context) -> {
+            Mockito.when(mock.parse(Matchers.anyString())).thenReturn(mockParseResponse);
+            mockParser = mock;
+        });
 
         cronParserField = new CronParserField(testFieldName, mockConstraints);
+    }
+
+    @After
+    public void tearDown() {
+        mockedConstruction.close();
     }
 
     @Test

--- a/src/test/java/com/cronutils/parser/CronParserQuartzIntegrationTest.java
+++ b/src/test/java/com/cronutils/parser/CronParserQuartzIntegrationTest.java
@@ -20,28 +20,21 @@ import com.cronutils.model.CronType;
 import com.cronutils.model.definition.CronDefinitionBuilder;
 import com.cronutils.model.field.expression.FieldExpressionFactory;
 import com.cronutils.model.time.ExecutionTime;
-import org.hamcrest.core.StringEndsWith;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.time.ZonedDateTime;
 import java.util.Locale;
 import java.util.Optional;
 
-import static org.junit.Assert.*;
-import static org.junit.internal.matchers.ThrowableMessageMatcher.hasMessage;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class CronParserQuartzIntegrationTest {
 
     private static final String LAST_EXECUTION_NOT_PRESENT_ERROR = "last execution was not present";
     private CronParser parser;
 
-    @Rule
-    public ExpectedException thrown = ExpectedException.none();
-
-    @Before
+    @BeforeEach
     public void setUp() {
         parser = new CronParser(CronDefinitionBuilder.instanceDefinitionFor(CronType.QUARTZ));
     }
@@ -54,24 +47,24 @@ public class CronParserQuartzIntegrationTest {
      * we receive: NumberFormatException
      * Expected: throw IllegalArgumentException notifying invalid char was used
      */
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testInvalidCharsDetected() {
-        parser.parse("* * * * $ ?");
+        assertThrows(IllegalArgumentException.class, () -> parser.parse("* * * * $ ?"));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testInvalidCharsDetectedWithSingleSpecialChar() {
-        parser.parse("* * * * $W ?");
+        assertThrows(IllegalArgumentException.class, () -> parser.parse("* * * * $W ?"));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testInvalidCharsDetectedWithHashExpression1() {
-        parser.parse("* * * * $#3 ?");
+        assertThrows(IllegalArgumentException.class, () -> parser.parse("* * * * $#3 ?"));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testInvalidCharsDetectedWithHashExpression2() {
-        parser.parse("* * * * 3#$ ?");
+        assertThrows(IllegalArgumentException.class, () -> parser.parse("* * * * 3#$ ?"));
     }
 
     /**
@@ -85,9 +78,9 @@ public class CronParserQuartzIntegrationTest {
     /**
      * Issue #15: we should support L in range (ex.: L-3), but not other special chars
      */
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testLSupportedInRange() {
-        parser.parse("* * * W-3 * ?");
+        assertThrows(IllegalArgumentException.class, () -> parser.parse("* * * W-3 * ?"));
     }
 
     @Test
@@ -184,9 +177,9 @@ public class CronParserQuartzIntegrationTest {
     /**
      * Issue #63: Parser exception when parsing cron.
      */
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testDoMAndDoWParametersInvalidForQuartz() {
-        parser.parse("0 30 17 4 1 * 2016");
+        assertThrows(IllegalArgumentException.class, () -> parser.parse("0 30 17 4 1 * 2016"));
     }
 
     /**
@@ -226,9 +219,9 @@ public class CronParserQuartzIntegrationTest {
      */
     @Test
     public void testRegressionDifferentMessageForException() {
-        thrown.expect(IllegalArgumentException.class);
-        thrown.expectMessage("Invalid chars in expression! Expression: $ Invalid chars: $");
-        assertNotNull(ExecutionTime.forCron(parser.parse("* * * * $ ?")));
+        IllegalArgumentException e =
+                assertThrows(IllegalArgumentException.class, () -> assertNotNull(ExecutionTime.forCron(parser.parse("* * * * $ ?"))));
+        assertTrue(e.getMessage().contains("Invalid chars in expression! Expression: $ Invalid chars: $"));
     }
 
     /**
@@ -236,10 +229,9 @@ public class CronParserQuartzIntegrationTest {
      */
     @Test
     public void testReportedErrorContainsSameExpressionAsProvided() {
-        thrown.expect(IllegalArgumentException.class);
-        thrown.expectMessage(
-                "Invalid cron expression: 0/1 * * * * *. Both, a day-of-week AND a day-of-month parameter, are not supported.");
-        assertNotNull(ExecutionTime.forCron(parser.parse("0/1 * * * * *")));
+        IllegalArgumentException e =
+                assertThrows(IllegalArgumentException.class, () -> assertNotNull(ExecutionTime.forCron(parser.parse("0/1 * * * * *"))));
+        assertTrue(e.getMessage().contains("Invalid cron expression: 0/1 * * * * *. Both, a day-of-week AND a day-of-month parameter, are not supported."));
     }
 
     /**
@@ -248,10 +240,10 @@ public class CronParserQuartzIntegrationTest {
      */
     @Test
     public void testMissingExpressionAndInvalidCharsInErrorMessage() {
-        thrown.expect(IllegalArgumentException.class);
         final String cronexpression = "* * -1 * * ?";
-        thrown.expect(hasMessage(StringEndsWith.endsWith("Invalid expression! Expression: -1 does not describe a range. Negative numbers are not allowed.")));
-        assertNotNull(ExecutionTime.forCron(parser.parse(cronexpression)));
+        IllegalArgumentException e =
+                assertThrows(IllegalArgumentException.class, () -> ExecutionTime.forCron(parser.parse(cronexpression)));
+        assertTrue(e.getMessage().endsWith("Invalid expression! Expression: -1 does not describe a range. Negative numbers are not allowed."));
     }
 
     /**
@@ -270,8 +262,7 @@ public class CronParserQuartzIntegrationTest {
 
     @Test
     public void testRejectIllegalMonthArgument() {
-        thrown.expect(IllegalArgumentException.class);
-        CronBuilder.cron(CronDefinitionBuilder.instanceDefinitionFor(CronType.QUARTZ)).withMonth(FieldExpressionFactory.on(0));
+        assertThrows(IllegalArgumentException.class, () -> CronBuilder.cron(CronDefinitionBuilder.instanceDefinitionFor(CronType.QUARTZ)).withMonth(FieldExpressionFactory.on(0)));
     }
 
     /**
@@ -313,16 +304,16 @@ public class CronParserQuartzIntegrationTest {
 
     @Test
     public void testErrorAbout2Parts() {
-        thrown.expect(IllegalArgumentException.class);
-        thrown.expectMessage("Cron expression contains 2 parts but we expect one of [6, 7]");
-        assertNotNull(ExecutionTime.forCron(parser.parse("* *")));
+        IllegalArgumentException e =
+                assertThrows(IllegalArgumentException.class, () -> ExecutionTime.forCron(parser.parse("* *")));
+        assertEquals("Cron expression contains 2 parts but we expect one of [6, 7]", e.getMessage());
     }
 
     @Test
     public void testErrorAboutMissingSteps() {
-        thrown.expect(IllegalArgumentException.class);
-        thrown.expectMessage("Missing steps for expression: */");
-        assertNotNull(ExecutionTime.forCron(parser.parse("*/ * * * * ?")));
+        IllegalArgumentException e =
+                assertThrows(IllegalArgumentException.class, () -> ExecutionTime.forCron(parser.parse("*/ * * * * ?")));
+        assertTrue(e.getMessage().contains("Missing steps for expression: */"));
     }
 
     /**

--- a/src/test/java/com/cronutils/parser/CronParserSpringIntegrationTest.java
+++ b/src/test/java/com/cronutils/parser/CronParserSpringIntegrationTest.java
@@ -2,13 +2,13 @@ package com.cronutils.parser;
 
 import com.cronutils.model.CronType;
 import com.cronutils.model.definition.CronDefinitionBuilder;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.springframework.scheduling.support.CronExpression;
 
 public class CronParserSpringIntegrationTest {
     private CronParser parser;
-    @Before
+    @BeforeEach
     public void setUp() {
         parser = new CronParser(CronDefinitionBuilder.instanceDefinitionFor(CronType.SPRING));
     }

--- a/src/test/java/com/cronutils/parser/CronParserTest.java
+++ b/src/test/java/com/cronutils/parser/CronParserTest.java
@@ -21,10 +21,8 @@ import com.cronutils.model.definition.TestCronDefinitionsFactory;
 import com.cronutils.model.field.CronFieldName;
 import com.cronutils.model.field.constraint.FieldConstraintsBuilder;
 import com.cronutils.model.field.definition.FieldDefinition;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
@@ -32,40 +30,38 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.when;
 
 public class CronParserTest {
-    @Rule
-    public ExpectedException expectedException = ExpectedException.none();
-
     @Mock
     private CronDefinition definition;
 
     private CronParser parser;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         MockitoAnnotations.initMocks(this);
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testParseEmptyExpression() {
         when(definition.getFieldDefinitions()).thenReturn(Collections.emptySet());
         parser = new CronParser(definition);
 
-        parser.parse("");
+        assertThrows(IllegalArgumentException.class, () -> parser.parse(""));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testParseNoMatchingExpression() {
         final Set<FieldDefinition> set =
                 Collections.singleton(new FieldDefinition(CronFieldName.SECOND, FieldConstraintsBuilder.instance().createConstraintsInstance()));
         when(definition.getFieldDefinitions()).thenReturn(set);
         parser = new CronParser(definition);
 
-        parser.parse("* *");
+        assertThrows(IllegalArgumentException.class, () -> parser.parse("* *"));
     }
 
     @Test
@@ -80,29 +76,29 @@ public class CronParserTest {
         parser.parse(expression);
     }
 
-    @Test(expected = IllegalArgumentException.class) // issue #368
+    @Test // issue #368
     public void testTrailingCommaListCron4j(){
-        validateExpression(CronType.CRON4J, "1, * * * *");
+        assertThrows(IllegalArgumentException.class, () -> validateExpression(CronType.CRON4J, "1, * * * *"));
     }
 
-    @Test(expected = IllegalArgumentException.class) // issue #368
+    @Test // issue #368
     public void testTrailingCommaListQuartz(){
-        validateExpression(CronType.QUARTZ, "1, * * * * ?");
+        assertThrows(IllegalArgumentException.class, () -> validateExpression(CronType.QUARTZ, "1, * * * * ?"));
     }
 
-    @Test(expected = IllegalArgumentException.class) // issue #368
+    @Test // issue #368
     public void testTrailingCommaListSpring(){
-        validateExpression(CronType.SPRING, "1,2, * * * * ?");
+        assertThrows(IllegalArgumentException.class, () -> validateExpression(CronType.SPRING, "1,2, * * * * ?"));
     }
 
-    @Test(expected = IllegalArgumentException.class) // issue #368
+    @Test // issue #368
     public void testTrailingCommaListUnix(){
-        validateExpression(CronType.UNIX, "1, * * * *");
+        assertThrows(IllegalArgumentException.class, () -> validateExpression(CronType.UNIX, "1, * * * *"));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testHashListUnix(){
-        validateExpression(CronType.UNIX, "0 0 0 ? * #");
+        assertThrows(IllegalArgumentException.class, () -> validateExpression(CronType.UNIX, "0 0 0 ? * #"));
     }
 
     @Test // issue #369
@@ -121,10 +117,8 @@ public class CronParserTest {
         when(definition.getFieldDefinitions()).thenReturn(set);
         parser = new CronParser(definition);
 
-        expectedException.expect(IllegalArgumentException.class);
-        expectedException.expectMessage(expectedMessage);
-
-        assertNotNull(parser.parse(expression));
+        IllegalArgumentException e = assertThrows(IllegalArgumentException.class, () -> parser.parse(expression));
+        assertTrue(e.getMessage().contains(expectedMessage));
     }
 
     /**
@@ -171,19 +165,19 @@ public class CronParserTest {
         parser.parse("0/59 0/59 0/23 1/30 1/11 ? 2017/3");
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testRejectionOfZeroPeriod() {
         final CronDefinition quartzDefinition = CronDefinitionBuilder.instanceDefinitionFor(CronType.QUARTZ);
         parser = new CronParser(quartzDefinition);
 
-        parser.parse("0/0 0 0 1 1 ? 2017/3");
+        assertThrows(IllegalArgumentException.class, () -> parser.parse("0/0 0 0 1 1 ? 2017/3"));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testRejectionOfPeriodUpperLimitExceedance() {
         final CronDefinition quartzDefinition = CronDefinitionBuilder.instanceDefinitionFor(CronType.QUARTZ);
         parser = new CronParser(quartzDefinition);
-        parser.parse("0/60 0 0 1 1 ? 2017/3");
+        assertThrows(IllegalArgumentException.class, () -> parser.parse("0/60 0 0 1 1 ? 2017/3"));
     }
 
     @Test
@@ -221,9 +215,9 @@ public class CronParserTest {
         assertEquals(multicron, cron.asString());
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testParseQuartzCronWithHash() {
         parser = new CronParser(TestCronDefinitionsFactory.withDayOfYearDefinitionWhereYearAndDoYOptionals());
-        parser.parse("0 0 0 ? * #");
+        assertThrows(IllegalArgumentException.class, () -> parser.parse("0 0 0 ? * #"));
     }
 }

--- a/src/test/java/com/cronutils/utils/CronFrequencyComparatorTest.java
+++ b/src/test/java/com/cronutils/utils/CronFrequencyComparatorTest.java
@@ -5,14 +5,14 @@ import com.cronutils.model.CronType;
 import com.cronutils.model.definition.CronDefinition;
 import com.cronutils.model.definition.CronDefinitionBuilder;
 import com.cronutils.parser.CronParser;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class CronFrequencyComparatorTest {
     private CronFrequencyComparator comparator;
@@ -20,7 +20,7 @@ public class CronFrequencyComparatorTest {
     private Cron cron1;
     private Cron cron2;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         ZonedDateTime date1 = LocalDateTime.of(2018, 11, 5, 0, 0, 0).atZone(ZoneId.of("UTC"));
         ZonedDateTime date2 = LocalDateTime.of(2018, 11, 11, 0, 0, 0).atZone(ZoneId.of("UTC"));

--- a/src/test/java/com/cronutils/utils/DateUtilsTest.java
+++ b/src/test/java/com/cronutils/utils/DateUtilsTest.java
@@ -1,6 +1,6 @@
 package com.cronutils.utils;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.time.LocalDate;
 import java.time.LocalTime;
@@ -10,7 +10,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class DateUtilsTest {
 

--- a/src/test/java/com/cronutils/utils/StringUtilsTest.java
+++ b/src/test/java/com/cronutils/utils/StringUtilsTest.java
@@ -1,9 +1,9 @@
 package com.cronutils.utils;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class StringUtilsTest {
 

--- a/src/test/java/com/cronutils/utils/descriptor/CronDescriptorCron4jIntegrationTest.java
+++ b/src/test/java/com/cronutils/utils/descriptor/CronDescriptorCron4jIntegrationTest.java
@@ -17,12 +17,12 @@ import com.cronutils.descriptor.CronDescriptor;
 import com.cronutils.model.CronType;
 import com.cronutils.model.definition.CronDefinitionBuilder;
 import com.cronutils.parser.CronParser;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.Locale;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class CronDescriptorCron4jIntegrationTest {
 
@@ -30,7 +30,7 @@ public class CronDescriptorCron4jIntegrationTest {
     private CronDescriptor descriptor;
     private CronParser parser;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         descriptor = CronDescriptor.instance(Locale.UK);
         parser = new CronParser(CronDefinitionBuilder.instanceDefinitionFor(CronType.CRON4J));

--- a/src/test/java/com/cronutils/utils/descriptor/CronDescriptorCron4jIntegrationZhTest.java
+++ b/src/test/java/com/cronutils/utils/descriptor/CronDescriptorCron4jIntegrationZhTest.java
@@ -17,12 +17,12 @@ import com.cronutils.descriptor.CronDescriptor;
 import com.cronutils.model.CronType;
 import com.cronutils.model.definition.CronDefinitionBuilder;
 import com.cronutils.parser.CronParser;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.Locale;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * https://github.com/jmrozanec/cron-utils/issues/230
@@ -33,7 +33,7 @@ public class CronDescriptorCron4jIntegrationZhTest {
     private CronDescriptor descriptor;
     private CronParser parser;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         descriptor = CronDescriptor.instance(Locale.CHINESE);
         parser = new CronParser(CronDefinitionBuilder.instanceDefinitionFor(CronType.CRON4J));

--- a/src/test/java/com/cronutils/utils/descriptor/CronDescriptorQuartzIntegrationTest.java
+++ b/src/test/java/com/cronutils/utils/descriptor/CronDescriptorQuartzIntegrationTest.java
@@ -17,18 +17,18 @@ import com.cronutils.descriptor.CronDescriptor;
 import com.cronutils.model.CronType;
 import com.cronutils.model.definition.CronDefinitionBuilder;
 import com.cronutils.parser.CronParser;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.Locale;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class CronDescriptorQuartzIntegrationTest {
     private CronDescriptor descriptor;
     private CronParser parser;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         descriptor = CronDescriptor.instance(Locale.UK);
         parser = new CronParser(CronDefinitionBuilder.instanceDefinitionFor(CronType.QUARTZ));

--- a/src/test/java/com/cronutils/utils/descriptor/CronDescriptorTest.java
+++ b/src/test/java/com/cronutils/utils/descriptor/CronDescriptorTest.java
@@ -27,8 +27,8 @@ import com.cronutils.model.field.expression.On;
 import com.cronutils.model.field.value.IntegerFieldValue;
 import com.cronutils.model.field.value.SpecialChar;
 import com.cronutils.model.field.value.SpecialCharFieldValue;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
@@ -37,8 +37,8 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class CronDescriptorTest {
     private CronDescriptor descriptor;
@@ -46,7 +46,7 @@ public class CronDescriptorTest {
     @Mock
     private CronDefinition mockDefinition;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         MockitoAnnotations.initMocks(this);
         descriptor = CronDescriptor.instance(Locale.UK);

--- a/src/test/java/com/cronutils/utils/descriptor/Issue227Test.java
+++ b/src/test/java/com/cronutils/utils/descriptor/Issue227Test.java
@@ -18,12 +18,12 @@ import com.cronutils.model.Cron;
 import com.cronutils.model.CronType;
 import com.cronutils.model.definition.CronDefinitionBuilder;
 import com.cronutils.parser.CronParser;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.Locale;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class Issue227Test {
 
@@ -32,7 +32,7 @@ public class Issue227Test {
      */
     private CronParser parser;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         parser = new CronParser(CronDefinitionBuilder.instanceDefinitionFor(CronType.QUARTZ));
     }

--- a/src/test/java/com/cronutils/utils/descriptor/Issue281Test.java
+++ b/src/test/java/com/cronutils/utils/descriptor/Issue281Test.java
@@ -18,39 +18,40 @@ import com.cronutils.model.CronType;
 import com.cronutils.model.definition.CronDefinition;
 import com.cronutils.model.definition.CronDefinitionBuilder;
 import com.cronutils.parser.CronParser;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class Issue281Test {
 
     @Test
     public void shouldAcceptLastMonth() {
         final Cron cron = buildCron("0 0 0 24 1/12 ?");
-        assertThat("cron is not null", cron != null);
+        assertNotNull(cron, "cron is not null");
     }
 
     @Test
     public void shouldAcceptFirstMonth() {
         final Cron cron = buildCron("0 0 0 24/1 1/12 ?");
-        assertThat("cron is not null", cron != null);
+        assertNotNull(cron, "cron is not null");
     }
 
     @Test
     public void shouldAcceptLastDayOfMonth() {
         final Cron cron = buildCron("0 0 0 1/31 7 ?");
-        assertThat("cron is not null", cron != null);
+        assertNotNull(cron, "cron is not null");
     }
 
     @Test
     public void shouldAcceptFirstDayOfMonth() {
         final Cron cron = buildCron("0 0 0 24/1 1/12 ?");
-        assertThat("cron is not null", cron != null);
+        assertNotNull(cron, "cron is not null");
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void shouldThrowExceptionWhenMonthExceeded() {
-        buildCron("0 0 0 24 1/13 ?");
+        assertThrows(IllegalArgumentException.class, () -> buildCron("0 0 0 24 1/13 ?"));
     }
 
     private Cron buildCron(String expression) {

--- a/src/test/java/com/cronutils/utils/descriptor/Issue343Test.java
+++ b/src/test/java/com/cronutils/utils/descriptor/Issue343Test.java
@@ -6,22 +6,23 @@ import com.cronutils.model.definition.CronDefinition;
 import com.cronutils.model.definition.CronDefinitionBuilder;
 import com.cronutils.parser.CronParser;
 import org.hamcrest.core.IsEqual;
-import org.junit.Assert;
 import org.junit.runners.Parameterized.Parameters;
 
 import java.util.Locale;
 
+import static org.junit.Assert.assertThat;
+
 /**
  *  Issue 334 - Getting exception {@link IllegalArgumentException} "Both, a day-of-week AND a day-of-month parameter, are not supported."
  *  when trying to get description for valid cron expression with {@link CronDefinition} of {@link CronType#SPRING} type.
- *  
- **/ 
+ *
+ **/
 //@RunWith(Parameterized.class)
 public class Issue343Test {
-	
+
 	/**
 	 * Cron expressions from spring docs <a href="https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/scheduling/support/CronSequenceGenerator.html">Class CronSequenceGenerator</a>
-	 **/ 
+	 **/
 	@Parameters
 	public static Object[] expressions() {
 		return new Object[] {
@@ -33,33 +34,33 @@ public class Issue343Test {
 				new Expr("0 0 9-17 * * MON-FRI", "every hour between 9 and 17 every day between Monday and Friday")
 		};
 	}
-	
+
 	private Expr expressionToTest;
-	
+
 	public Issue343Test(Expr expressionToTest) {
 		this.expressionToTest = expressionToTest;
 	}
-	
+
 	//@Test
 	public void test() {
 		CronParser pareser = new CronParser( CronDefinitionBuilder.instanceDefinitionFor(CronType.SPRING) );
-		
+
 		String actualDescription = CronDescriptor.instance(Locale.ENGLISH)
 				.describe(pareser.parse(expressionToTest.getExpression()));
-		
-		Assert.assertThat(actualDescription, IsEqual.equalTo(expressionToTest.getExpectedDescription()));
+
+		assertThat(actualDescription, IsEqual.equalTo(expressionToTest.getExpectedDescription()));
 	}
-	
+
 	//@Test
 	public void workaround() {
 		CronParser pareser = new CronParser( workingSpringCronDefinition() );
-		
+
 		String actualDescription = CronDescriptor.instance(Locale.ENGLISH)
 				.describe(pareser.parse(expressionToTest.getExpression()));
-		
-		Assert.assertThat(actualDescription, IsEqual.equalTo(expressionToTest.getExpectedDescription()));
+
+		assertThat(actualDescription, IsEqual.equalTo(expressionToTest.getExpectedDescription()));
 	}
-	
+
 	private static CronDefinition workingSpringCronDefinition() {
         return CronDefinitionBuilder.defineCron()
                 .withSeconds().and()
@@ -71,12 +72,12 @@ public class Issue343Test {
 //                .withCronValidation(CronConstraintsFactory.ensureEitherDayOfWeekOrDayOfMonth())
                 .instance();
     }
-	
-	
+
+
 	private static class Expr {
 		private final String expression;
 		private final String expectedDescription;
-		
+
 		public Expr(String expression, String expectedDescription) {
 			super();
 			this.expression = expression;

--- a/src/test/java/com/cronutils/utils/descriptor/Issue343Test.java
+++ b/src/test/java/com/cronutils/utils/descriptor/Issue343Test.java
@@ -5,60 +5,56 @@ import com.cronutils.model.CronType;
 import com.cronutils.model.definition.CronDefinition;
 import com.cronutils.model.definition.CronDefinitionBuilder;
 import com.cronutils.parser.CronParser;
-import org.hamcrest.core.IsEqual;
-import org.junit.runners.Parameterized.Parameters;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.util.Locale;
+import java.util.stream.Stream;
 
-import static org.junit.Assert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 
 /**
  *  Issue 334 - Getting exception {@link IllegalArgumentException} "Both, a day-of-week AND a day-of-month parameter, are not supported."
  *  when trying to get description for valid cron expression with {@link CronDefinition} of {@link CronType#SPRING} type.
  *
  **/
-//@RunWith(Parameterized.class)
 public class Issue343Test {
 
 	/**
 	 * Cron expressions from spring docs <a href="https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/scheduling/support/CronSequenceGenerator.html">Class CronSequenceGenerator</a>
 	 **/
-	@Parameters
-	public static Object[] expressions() {
-		return new Object[] {
+	public static Stream<Expr> expressions() {
+		return Stream.of(
 				new Expr("0 0 * * * *", "every hour"),
 				new Expr("*/10 * * * * *", "every 10 seconds"),
 				new Expr("0 0 8-10 * * *", "every hour between 8 and 10"),
 				new Expr("0 0 6,19 * * *", "at 6 and 19 hours"),
 				new Expr("0 0/30 8-10 * * *", "every 30 minutes every hour between 8 and 10"),
 				new Expr("0 0 9-17 * * MON-FRI", "every hour between 9 and 17 every day between Monday and Friday")
-		};
+		);
 	}
 
-	private Expr expressionToTest;
-
-	public Issue343Test(Expr expressionToTest) {
-		this.expressionToTest = expressionToTest;
-	}
-
-	//@Test
-	public void test() {
+	@ParameterizedTest
+	@MethodSource("expressions")
+	public void test(Expr expressionToTest) {
 		CronParser pareser = new CronParser( CronDefinitionBuilder.instanceDefinitionFor(CronType.SPRING) );
 
 		String actualDescription = CronDescriptor.instance(Locale.ENGLISH)
 				.describe(pareser.parse(expressionToTest.getExpression()));
 
-		assertThat(actualDescription, IsEqual.equalTo(expressionToTest.getExpectedDescription()));
+		assertEquals(expressionToTest.getExpectedDescription(), actualDescription);
 	}
 
-	//@Test
-	public void workaround() {
+	@ParameterizedTest
+	@MethodSource("expressions")
+	public void workaround(Expr expressionToTest) {
 		CronParser pareser = new CronParser( workingSpringCronDefinition() );
 
 		String actualDescription = CronDescriptor.instance(Locale.ENGLISH)
 				.describe(pareser.parse(expressionToTest.getExpression()));
 
-		assertThat(actualDescription, IsEqual.equalTo(expressionToTest.getExpectedDescription()));
+		assertEquals(expressionToTest.getExpectedDescription(), actualDescription);
 	}
 
 	private static CronDefinition workingSpringCronDefinition() {

--- a/src/test/java/com/cronutils/utils/descriptor/TestDescriptor.java
+++ b/src/test/java/com/cronutils/utils/descriptor/TestDescriptor.java
@@ -1,12 +1,12 @@
 package com.cronutils.utils.descriptor;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.Locale;
 import java.util.ResourceBundle;
 
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 import com.cronutils.descriptor.CronDescriptor;
 import com.cronutils.descriptor.refactor.TimeDescriptor;
@@ -31,7 +31,7 @@ public class TestDescriptor {
 	// every 2 days starting on the 9th,
 	// every 2 months starting in October,
 	// every 2 years starting in 2017
-	@Ignore
+	@Disabled
 	@Test
 	public void testFull() {
 		final Cron cron = getCron("3/4 5/6 7/8 9/2 10/2 ? 2017");
@@ -132,7 +132,7 @@ public class TestDescriptor {
 		assertEquals(descriptor.describe(cron), descriptor.describe(otherCron));
 	}
 
-	@Ignore
+	@Disabled
 	@Test
 	public void testAtSecondEveryMinute() {
 		final Cron cron = getCron("1 * * * * ? *");
@@ -141,7 +141,7 @@ public class TestDescriptor {
 		assertEquals("at second 15 of every minute", descriptor.describe(otherCron));
 	}
 
-	@Ignore
+	@Disabled
 	@Test
 	public void testAtSecondEveryMinuteWithoutYear() {
 		final Cron cron = getCron("1 * * * * ?");
@@ -150,7 +150,7 @@ public class TestDescriptor {
 		assertEquals("at second 15 of every minute", descriptor.describe(otherCron));
 	}
 
-	@Ignore
+	@Disabled
 	@Test
 	public void testEverySecondDuringMinuteOfEveryHour() {
 		final Cron cron = getCron("* 1 * * * ? *");
@@ -159,7 +159,7 @@ public class TestDescriptor {
 		assertEquals("every second during minute 15 of every hour", descriptor.describe(otherCron));
 	}
 
-	@Ignore
+	@Disabled
 	@Test
 	public void testEverySecondDuringMinuteOfEveryHourWithoutYear() {
 		final Cron cron = getCron("* 1 * * * ?");
@@ -168,7 +168,7 @@ public class TestDescriptor {
 		assertEquals("every second during minute 15 of every hour", descriptor.describe(otherCron));
 	}
 
-	@Ignore
+	@Disabled
 	@Test
 	public void testEverySecondOnTheDayEveryMonth() {
 		final Cron first = getCron("* * * 1 * ? *");
@@ -181,7 +181,7 @@ public class TestDescriptor {
 		assertEquals("every second, on the 15th day, every month", descriptor.describe(otherCron));
 	}
 
-	@Ignore
+	@Disabled
 	@Test
 	public void testEverySecondOnTheDayEveryMonthWithoutYear() {
 		final Cron first = getCron("* * * 1 * ?");
@@ -194,7 +194,7 @@ public class TestDescriptor {
 		assertEquals("every second, on the 15th day, every month", descriptor.describe(otherCron));
 	}
 
-	@Ignore
+	@Disabled
 	@Test
 	public void testEverySecondEveryDayInMonth() {
 		final Cron cron = getCron("* * * * 1 ? *");
@@ -203,7 +203,7 @@ public class TestDescriptor {
 		assertEquals("every second, every day, in December", descriptor.describe(otherCron));
 	}
 
-	@Ignore
+	@Disabled
 	@Test
 	public void testEverySecondEveryDayInMonthWithoutYear() {
 		final Cron cron = getCron("* * * * 1 ?");
@@ -212,7 +212,7 @@ public class TestDescriptor {
 		assertEquals("every second, every day, in December", descriptor.describe(otherCron));
 	}
 
-	@Ignore
+	@Disabled
 	@Test
 	public void testEverySecondEveryDayInYear() {
 		final Cron cron = getCron("* * * * * ? 2017");
@@ -222,63 +222,63 @@ public class TestDescriptor {
 		assertEquals("every second, every day, in 2018", descriptor.describe(otherCron));
 	}
 
-	@Ignore
+	@Disabled
 	@Test
 	public void testAtTimeEveryDay() {
 		final Cron cron = getCron("0 0 0 * * ? *");
 		assertEquals("at 00:00:00am every day", descriptor.describe(cron));
 	}
 
-	@Ignore
+	@Disabled
 	@Test
 	public void testAtTimeEveryDay2() {
 		final Cron cron = getCron("00 00 16 * * ? *");
 		assertEquals("at 16:00:00pm every day", descriptor.describe(cron));
 	}
 
-	@Ignore
+	@Disabled
 	@Test
 	public void testAtMultipleTimesEveryDay() {
 		final Cron cron = getCron("00 00 8,16 * * ? *");
 		assertEquals("at second 00, at minute 00, at 08am and 16pm, of every day", descriptor.describe(cron));
 	}
 
-	@Ignore
+	@Disabled
 	@Test
 	public void testAtTimeOfDayEveryMonth() {
 		final Cron cron = getCron("0 0 16 1 * ? *");
 		assertEquals("at 16:00:00pm, on the first day, every month", descriptor.describe(cron));
 	}
 
-	@Ignore
+	@Disabled
 	@Test
 	public void testAtTimeOfMultipleDaysEveryMonth() {
 		final Cron cron = getCron("0 0 16 1,5,26 * ? *");
 		assertEquals("at 16:00:00pm on the 1st, 5th and 26th day, every month", descriptor.describe(cron));
 	}
 
-	@Ignore
+	@Disabled
 	@Test
 	public void testAtTimeOfEveryDayInMonth() {
 		final Cron cron = getCron("0 0 16 * 3 ? *");
 		assertEquals("at 16:00:00pm, every day, in March", descriptor.describe(cron));
 	}
 
-	@Ignore
+	@Disabled
 	@Test
 	public void testAtTimeOfEveryDayInMultipleMonth() {
 		final Cron cron = getCron("0 0 16 * 1,5,12 ? *");
 		assertEquals("at 16:00:00pm, every day in January, May and December", descriptor.describe(cron));
 	}
 
-	@Ignore
+	@Disabled
 	@Test
 	public void testAtTimeOfEveryDayBetweenMonths() {
 		final Cron cron = getCron("0 0 16 * 3-7 ? *");
 		assertEquals("at 16:00:00pm, every day between March and July", descriptor.describe(cron));
 	}
 
-	@Ignore
+	@Disabled
 	@Test
 	public void testAtTimeOfEveryDayBetweenMultipleMonths() {
 		final Cron cron = getCron("0 0 16 * 3-7,10-12 ? *");
@@ -286,42 +286,42 @@ public class TestDescriptor {
 				descriptor.describe(cron));
 	}
 
-	@Ignore
+	@Disabled
 	@Test
 	public void testAtTimeOfFirstInMultipleMonths() {
 		final Cron cron = getCron("0 0 16 1 3,5,12 ? *");
 		assertEquals("at 16:00:00pm, on the 1st day in March, May and December", descriptor.describe(cron));
 	}
 
-	@Ignore
+	@Disabled
 	@Test
 	public void testAtTimeOfSecondInMultipleMonths() {
 		final Cron cron = getCron("0 0 16 2 3,5,12 ? *");
 		assertEquals("at 16:00:00pm, on the 2nd day in March, May and December", descriptor.describe(cron));
 	}
 
-	@Ignore
+	@Disabled
 	@Test
 	public void testAtTimeOfThirdInMultipleMonths() {
 		final Cron cron = getCron("0 0 16 3 3,5,12 ? *");
 		assertEquals("at 16:00:00pm, on the 3rd day in March, May and December", descriptor.describe(cron));
 	}
 
-	@Ignore
+	@Disabled
 	@Test
 	public void testAtTimeOfSpecificDayInMultipleMonths() {
 		final Cron cron = getCron("0 0 16 15 3,5,12 ? *");
 		assertEquals("at 16:00:00pm, on the 15th day in March, May and December", descriptor.describe(cron));
 	}
 
-	@Ignore
+	@Disabled
 	@Test
 	public void testAtTimeOfSpecificDayBetweenMonths() {
 		final Cron cron = getCron("0 0 16 15 3-7 ? *");
 		assertEquals("at 16:00:00pm, on the 15th day every month between March and July", descriptor.describe(cron));
 	}
 
-	@Ignore
+	@Disabled
 	@Test
 	public void testAtTimeOfSpecificDayBetweenMultipleMonths() {
 		final Cron cron = getCron("0 0 16 15 3-7,10-12 ? *");
@@ -330,56 +330,56 @@ public class TestDescriptor {
 				descriptor.describe(cron));
 	}
 
-	@Ignore
+	@Disabled
 	@Test
 	public void testAtTimeOnLastDayOfMonth() {
 		final Cron cron = getCron("0 0 16 L * ? *");
 		assertEquals("at 16:00:00pm, on the last day of the month, every month", descriptor.describe(cron));
 	}
 
-	@Ignore
+	@Disabled
 	@Test
 	public void testAtTimeOnLastDayOfSpecificMonth() {
 		final Cron cron = getCron("0 0 16 L 3 ? *");
 		assertEquals("at 16:00:00pm, on the last day of the month, in March", descriptor.describe(cron));
 	}
 
-	@Ignore
+	@Disabled
 	@Test
 	public void testAtTimeOnThirdLastDayOfMonth() {
 		final Cron cron = getCron("0 0 16 L-3 * ? *");
 		assertEquals("at 16:00:00pm, 3 days before the end of the month, every month", descriptor.describe(cron));
 	}
 
-	@Ignore
+	@Disabled
 	@Test
 	public void testAtTimeOnNthSpecificWeekdayOfMonth() {
 		final Cron cron = getCron("0 0 16 ? * 5#2 *");
 		assertEquals("at 16:00:00pm, on the 2nd Thursday of the month, every month", descriptor.describe(cron));
 	}
 
-	@Ignore
+	@Disabled
 	@Test
 	public void testAtTimeOnLastSpecificWeekdayOfMonth() {
 		final Cron cron = getCron("0 0 16 ? * 2L *");
 		assertEquals("at 16:00:00pm, on the last Monday of the month, every month", descriptor.describe(cron));
 	}
 
-	@Ignore
+	@Disabled
 	@Test
 	public void testAtTimeEverySpecificWeekdayOfMonth() {
 		final Cron cron = getCron("0 0 16 ? * 2 *");
 		assertEquals("at 16:00:00pm, every Monday of the month, every month", descriptor.describe(cron));
 	}
 
-	@Ignore
+	@Disabled
 	@Test
 	public void testAtTimeEverySpecificWeekdayOfSpecificMonth() {
 		final Cron cron = getCron("0 0 16 ? 5 3 *");
 		assertEquals("at 16:00:00pm, every Tuesday of the month, in May", descriptor.describe(cron));
 	}
 
-	@Ignore
+	@Disabled
 	@Test
 	public void testAtTimeMultipleWeekdaysOfMultipleSpecificMonths() {
 		final Cron cron = getCron("0 0 16 ? 1,5,12 2,5,7 *");

--- a/src/test/java/com/cronutils/validator/CronValidatorQuartzIntegrationTest.java
+++ b/src/test/java/com/cronutils/validator/CronValidatorQuartzIntegrationTest.java
@@ -16,19 +16,19 @@ package com.cronutils.validator;
 import com.cronutils.model.CronType;
 import com.cronutils.model.definition.CronDefinitionBuilder;
 import com.cronutils.parser.CronParser;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.util.Locale;
 
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 public class CronValidatorQuartzIntegrationTest {
     private CronParser parser;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         parser = new CronParser(CronDefinitionBuilder.instanceDefinitionFor(CronType.QUARTZ));
     }


### PR DESCRIPTION
The project currently uses a mixture of JUnit 4 and JUnit Jupiter which while it isn't a problem per-se is confusing at best and may cause sublte bugs at worst.
This PR standardizes the entire project to use the newer JUnit Jupiter in order to make it easier to maintain.

It includes the following changes:

1. Maven
   1. Replaced the `org.junit.jupiter:junit-jupiter-api:5.8.1` dependency with the broader `org.junit.jupiter:junit-jupiter:5.8.1` dependency. This dependency also includes the classes needed for writing parameterized tests in JUnit Jupiter, as described in 2.iii.
   2. . Removed the `pl.pragmatists:JUnitParams:1.1.1` dependency which is no longer used. Note that the project does not contain an explicit dependency on `org.junit:junit:4.12` with provides the JUnit 4 classes, but it was transitively available via this dependency.
   3. Added an explicit dependency on `org.mockito:mockito-inline:3.9.0` in order to use Mockito's inline mock maker's capabilities.
   4. Removed the `org.powermock:powermock-module-junit4:2.0.9` dependency which is no longer used, see 6.i and 6.ii.
   5. Removed the `org.powermock:powermock-api-mockito2:2.0.9` dependency which is no longer used, see 6.i and 6.ii.
   6.  Removed the `org.mockito:mockito-junit-jupiter:3.9.0` dependency. The classes provided by this dependency were never used, and it was only useful for getting the indirect dependency `org.mockito:mockito-all:3.9.0`. With the explicit dependency described in 1.iii, this is no longer required.
1. Annotations
   1. `org.junit.jupiter.api.Test` is used as a drop-in replacement for `org.junit.Test` in the simple case where it was used without any additional parameters.
   2. `org.junit.jupiter.api.Test` is used instead of `org.junit.Test` with the `expected` argument, although in this case the assertions needed to be changed too, see 5.iv.
   3. `org.junit.jupiter.params.ParameterizedTest` is used instead of `org.junit.Test` in the cases where the test was parameterized, although additional changes were required, see 4.i and 4.ii. In the simple case the parameters were strings an `org.junit.jupiter.params.provider.ValueSource` annotation was added, and in other cases an `org,junit.Jupiter.params.provider.MethodSource` was used.
   7. `org.junit.jupiter.api.BeforeEach` is used as drop-in replacement for `org.junit.Before`.
   8. `org.junit.jupiter.api.Disabled` is used as drop-in replacement for `org.junit.Ignore`.
   9. Usages of the `org.powermock.core.classloader.annotations.PrepareForTest` annotation were removed, see 6.i and 6.ii for details.
1. Rules
   1. JUnit Jupiter does not support `Rule` annotations. The existing `ExpectedException` rules were removed and replaced with other mechanisms, see 5.iv.
1. Runners
   1. The usage of `org.junit.runner.Parameterized` were removed and the tests were rewritten to use the `ParameterizedTest` annotation, see 2.iii.
   2. The usage of `junitparams.JUnitParamsRunner` was removed and the tests were rewritten to use the `ParameterizedTest` annotation, see 2.iii.
1. Assertions
   1. `org.junit.jupiter.api.Assertions`' methods are used as drop-in replacements for the methods with the same name from `org.junit.Assert` in the simple case the method was called without the optional `message` argument.
   2. `org.junit.jupiter.api.Assertions`' methods are used as replacements for `org.junit.Assert`'s methods with the same name also in the case where a `message` argument was used, but in this case the arguments needed to be permuted and the `message` argument moved from the being the first argument to being the last argument.
   3. `org.junit.jupiter.api.Assertions`' methods are used as drop-in replacements for the methods with the same name from `junit.framework.Assert`.
   5. `org.junit.jupiter.api.Assertions`' methods are used as drop-in replacements for the methods with the same name from `junit.framework.TestCase`.
   6. `org.junit.jupiter.api.Assertions` does not have an equivalent of `org.junit.Assert`'s `assertThat` method. In the cases it was used, the assertion was rewritten to use `assertTrue` or `assertEquals` where possible.
   10. `org.junit.jupiter.api.Assertions`' `assertThrows` method was used to rewrite tests that used the `org.junit.Test` annotation with the `expected` argument (see 2.ii). As a side bonus, using this method allowed writing a stricter test where the exception must be thrown from the expected call instead of some arbitrary statement in the test. This, in turn, uncovered some dead code in those methods that could be removed.
   11. `org.junit.jupiter.api.Assertions`' `assertThrows` method was used to rewrite tests that used the `ExpectedException` Rule (see 3.iii).
1. Mocking
   1. Usages of `org.powermock.api.mockito.PowerMockito`'s `mockStatic` were replaced with equivalent calls to `org.mockito.Mockito`' `mockStatic`.
   2. Usages of `org.powermock.api.mockito.PowerMockito`'s `whenNew` were replaced with equivalent calls to `org.mockito.Mockito`' `mockConstruction`.
   3. New `tearDown` methods annotated with `org.junit.jupiter.api.AfterEach` were added to close the `MockedStatic` and `MockedConstruction` instances created from the changes in 6.i and 6.ii.
1. Code cleanups
   1. In order to make the work on this PR easier, imports of `org.junit.Assert` were replaced with static imports of the relevant methods, as per what seems to be the defacto standard for this project.
   4. Unused imports in test files were removed.
1. Specific test fixes
   1. `BetweenFieldValueGeneratorTest`'s `testGenerateNextValue` and `testGeneratePreviousValue` did not fail, but they were subtly wrong. In both tests, the loops have one iteration too many, meaning the last iteration of the loop will throw the expected `NoSuchValueException`, and the statement after the loop will never be executed.
   2. `CompositeCronTest`'s `weDoNotSupportCronsWithDifferentDefinitions` didn't fail, but it is was subtly wrong. The statement `parser2.parse("0 0 1 * *")` throws an `IllegalArgumentException` (causing the test to pass), and by doing so the call to the `CompositeCron`'s constructor which is what this method is supposed to test is never called.
   3. `Issue499Test` was never run - it used `org.junit.Test`, but the class is not public, so it's never picked up by the test runner. It was converted to use `org.junit.jupiter.api.Test` with `assertThrows`, and the dead code that tested the behavior before #499 was fixed was removed.

Individual commit messages contain additional details and context not described here.