### PR TITLE
Adding Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+version: 2
+updates:
+  - package-ecosystem: maven
+    directory: "/"
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"


### PR DESCRIPTION
Fixes #542 - i.e. adds Dependabot back to the repository.

I suggest to merge #543 first to avoid the initial flood of PRs suggesting to upgrade Maven plugins.