### PR TITLE
Describe explicit minute 0 when seconds are not implicit

### DIFF
--- a/src/main/java/com/cronutils/descriptor/TimeDescriptionStrategy.java
+++ b/src/main/java/com/cronutils/descriptor/TimeDescriptionStrategy.java
@@ -19,7 +19,7 @@ import com.cronutils.model.field.value.IntegerFieldValue;
 import com.cronutils.utils.Preconditions;
 import com.cronutils.utils.StringUtils;
 
-import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.ResourceBundle;
 import java.util.Set;
 
@@ -59,7 +59,7 @@ class TimeDescriptionStrategy extends DescriptionStrategy {
 		this.hours = ensureInstance(hours, always());
 		this.minutes = ensureInstance(minutes, always());
 		this.seconds = ensureInstance(seconds, new On(new IntegerFieldValue(DEFAULTSECONDS)));
-		descriptions = new HashSet<>();
+		descriptions = new LinkedHashSet<>();
 		registerFunctions();
 	}
 
@@ -85,20 +85,23 @@ class TimeDescriptionStrategy extends DescriptionStrategy {
 	public String describe() {
 		final TimeFields fields = new TimeFields(hours, minutes, seconds);
 		for (final Function<TimeFields, String> function : descriptions) {
-			if (!"".equals(function.apply(fields))) {
-				return function.apply(fields);
+			final String description = function.apply(fields);
+			if (!"".equals(description)) {
+				return description;
 			}
 		}
 		String secondsDesc = "";
 		String minutesDesc = "";
 		String hoursDesc = "";
+		// minute 0 may only stay implicit while seconds are too, else we claim an unbounded sub-minute frequency
+		final boolean defaultSeconds = seconds instanceof On && isDefault((On) seconds);
 		if (!(hours instanceof Always)) {
 			hoursDesc = addTimeExpressions(describe(hours), bundle.getString(HOUR), bundle.getString("hours"));
 		}
-		if (!(minutes instanceof On && isDefault((On) minutes)) && !((minutes instanceof Always) && (hours instanceof Always))) {
+		if (!(minutes instanceof On && isDefault((On) minutes) && defaultSeconds) && !((minutes instanceof Always) && (hours instanceof Always))) {
 			minutesDesc = addTimeExpressions(describe(minutes), bundle.getString(MINUTE), bundle.getString("minutes"));
 		}
-		if (!(seconds instanceof On && isDefault((On) seconds))) {
+		if (!defaultSeconds) {
 			secondsDesc = addTimeExpressions(describe(seconds), bundle.getString(SECOND), bundle.getString("seconds"));
 		}
 		return String.format("%s %s %s", secondsDesc, minutesDesc, hoursDesc);

--- a/src/test/java/com/cronutils/utils/descriptor/Issue3Test.java
+++ b/src/test/java/com/cronutils/utils/descriptor/Issue3Test.java
@@ -1,0 +1,51 @@
+package com.cronutils.utils.descriptor;
+
+import com.cronutils.descriptor.CronDescriptor;
+import com.cronutils.model.CronType;
+import com.cronutils.model.definition.CronDefinitionBuilder;
+import com.cronutils.parser.CronParser;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import java.util.Locale;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Issue 3 - a cron firing on an explicit minute 0 lost that minute in its description, so
+ * "* 0 9-23 * * ?" read as "every second every hour between 9 and 23" and claimed roughly
+ * sixty times the firings the expression actually produces.
+ */
+public class Issue3Test {
+
+    private final CronParser parser = new CronParser(CronDefinitionBuilder.instanceDefinitionFor(CronType.QUARTZ));
+
+    @ParameterizedTest
+    @CsvSource({
+            "'* 0 9-23 * * ?', 'every second at 0 minute every hour between 9 and 23'",
+            "'5 0 9-23 * * ?', 'at 5 second at 0 minute every hour between 9 and 23'",
+            "'0/5 0 * * * ?',  'every 5 seconds from second 0 at 0 minute'",
+            "'* 0 */4 * * ?',  'every second at 0 minute every 4 hours'"
+    })
+    public void explicitMinuteZeroIsDescribedWhenSecondsAreNotImplicit(String expression, String expected) {
+        assertEquals(expected, CronDescriptor.instance(Locale.ENGLISH).describe(parser.parse(expression)));
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+            "'0 0 9-23 * * ?', 'every hour between 9 and 23'",
+            "'0 0 10 * * ?',   'at 10:00'"
+    })
+    public void minuteZeroStaysImplicitWhenSecondsAreImplicitToo(String expression, String expected) {
+        assertEquals(expected, CronDescriptor.instance(Locale.ENGLISH).describe(parser.parse(expression)));
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+            "'* 30 9-23 * * ?', 'every second at 30 minute every hour between 9 and 23'",
+            "'* 0 10 * * ?',    'every second at 10:00'"
+    })
+    public void nonZeroAndCollapsibleMinutesAreUnaffected(String expression, String expected) {
+        assertEquals(expected, CronDescriptor.instance(Locale.ENGLISH).describe(parser.parse(expression)));
+    }
+}


### PR DESCRIPTION
### Description of your changes

`TimeDescriptionStrategy` always suppressed the minute when it was `On(0)`, treating minute 0 as an implied default. That reads well when the seconds are implicit too, but when they are not, the description asserts a sub-minute frequency with nothing bounding it to the minute the cron actually fires on:

```
* 0 9-23 * * ?   before: every second every hour between 9 and 23
                 after:  every second at 0 minute every hour between 9 and 23
```

This is the case reported in #3 by @natrajmolala, where you invited a PR with a test.

The fix gates the existing suppression on the seconds also being default. Three related expressions were wrong in the same way and are corrected by the same condition:

| expression | before | after |
| --- | --- | --- |
| `5 0 9-23 * * ?` | at 5 second every hour between 9 and 23 | at 5 second at 0 minute every hour between 9 and 23 |
| `0/5 0 * * * ?` | every 5 seconds from second 0 | every 5 seconds from second 0 at 0 minute |
| `* 0 */4 * * ?` | every second every 4 hours | every second at 0 minute every 4 hours |

Where the suppression is deliberate it is preserved — `0 0 9-23 * * ?` still describes as "every hour between 9 and 23" and `0 0 10 * * ?` as "at 10:00". `Issue3Test` pins those too, so the collapse cannot regress.

#### Scope

#3 is an umbrella issue and this closes one reported case out of four; the others are phrasing rather than correctness, so the commit says `Refs #3` rather than `Fixes`.

#### Incidental

The strategy set is now insertion ordered and the duplicated predicate call in the match loop is hoisted. Both are hardening only — the eleven registered predicates cover mutually exclusive `(hours, minutes, seconds)` type triples, so the previous `HashSet` iteration order was not reachable as nondeterministic output.

### Impact Analysis

Output changes only for expressions that fire on an explicit minute 0 with non-default seconds, which were describing roughly sixty times the firings they actually produce. Callers asserting on those exact strings will need updating. No API, parser or i18n bundle changes, so no new resource keys and no impact on the non-English locales.

#### Checklist

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Existing tests pass: 810 tests, 0 failures, 0 errors (up from 802 on master by the 8 added cases; 57 pre-existing skips)
